### PR TITLE
refactor: rename go modules

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,5 +61,5 @@ jobs:
             ${{ runner.os }}-go-
       
       - name: Run Unit Tests
-        run: go test logto.io/core -v
+        run: go test github.com/logto-io/go/core -v
         

--- a/client/client.go
+++ b/client/client.go
@@ -7,7 +7,7 @@ import (
 
 	"golang.org/x/exp/slices"
 
-	"logto.io/core"
+	"github.com/logto-io/go/core"
 )
 
 type LogtoConfig struct {

--- a/client/go.mod
+++ b/client/go.mod
@@ -1,11 +1,11 @@
-module logto.io/client
+module github.com/logto-io/go/client
 
 go 1.19
 
 require (
 	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e
 	gopkg.in/square/go-jose.v2 v2.6.0
-	logto.io/core v0.0.0-00010101000000-000000000000
+	github.com/logto-io/go/core v0.0.0-00010101000000-000000000000
 )
 
 require (
@@ -15,4 +15,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace logto.io/core => ../core/
+replace github.com/logto-io/go/core => ../core/

--- a/client/handle_sign_in_callback.go
+++ b/client/handle_sign_in_callback.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"time"
 
-	"logto.io/core"
+	"github.com/logto-io/go/core"
 )
 
 func (logtoClient *LogtoClient) HandleSignInCallback(request *http.Request) error {

--- a/client/helper.go
+++ b/client/helper.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"net/url"
 
+	"github.com/logto-io/go/core"
 	"gopkg.in/square/go-jose.v2"
-	"logto.io/core"
 )
 
 func (logtoClient *LogtoClient) fetchOidcConfig() (core.OidcConfigResponse, error) {

--- a/client/sign_in.go
+++ b/client/sign_in.go
@@ -3,7 +3,7 @@ package client
 import (
 	"encoding/json"
 
-	"logto.io/core"
+	"github.com/logto-io/go/core"
 )
 
 type SignInContext struct {

--- a/client/sign_out.go
+++ b/client/sign_out.go
@@ -3,7 +3,7 @@ package client
 import (
 	"errors"
 
-	"logto.io/core"
+	"github.com/logto-io/go/core"
 )
 
 func (logtoClient *LogtoClient) SignOut(postLogoutRedirectUri string) (string, error) {

--- a/core/go.mod
+++ b/core/go.mod
@@ -1,4 +1,4 @@
-module logto.io/core
+module github.com/logto-io/go/core
 
 go 1.19
 

--- a/gin-sample/go.mod
+++ b/gin-sample/go.mod
@@ -1,4 +1,4 @@
-module logto.io/gin-sample
+module github.com/logto-io/go/gin-sample
 
 go 1.19
 

--- a/gin-sample/go.mod
+++ b/gin-sample/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/gin-contrib/sessions v0.0.5
 	github.com/gin-gonic/gin v1.8.1
-	logto.io/client v0.0.0-00010101000000-000000000000
+	github.com/logto-io/go/client v0.0.0-00010101000000-000000000000
 )
 
 require (
@@ -33,10 +33,10 @@ require (
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/square/go-jose.v2 v2.6.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	logto.io/core v0.0.0-00010101000000-000000000000 // indirect
+	github.com/logto-io/go/core v0.0.0-00010101000000-000000000000 // indirect
 )
 
 replace (
-	logto.io/client => ../client
-	logto.io/core => ../core
+	github.com/logto-io/go/client => ../client
+	github.com/logto-io/go/core => ../core
 )

--- a/gin-sample/main.go
+++ b/gin-sample/main.go
@@ -6,7 +6,7 @@ import (
 	"github.com/gin-contrib/sessions"
 	"github.com/gin-contrib/sessions/memstore"
 	"github.com/gin-gonic/gin"
-	"logto.io/client"
+	"github.com/logto-io/go/client"
 )
 
 var (


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
Rename go modules under `github.com` so that we can install the deps from github.com
* rename go module `logto.io/core` => `github.com/logto-io/go/core`
* rename go module `logto.io/client` => `github.com/logto-io/go/client`
* rename go module `logto.io/gin-sample` => `github.com/logto-io/go/gin-sample`

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally.
