### PR TITLE
fix(client): skip resource check in `GetAccessToken` when resource is empty string

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -87,9 +87,10 @@ func (logtoClient *LogtoClient) GetAccessToken(resource string) (AccessToken, er
 		return AccessToken{}, ErrNotAuthenticated
 	}
 
-	// TODO: do not check granted resource if resource is empty
-	if !slices.Contains(logtoClient.logtoConfig.Resources, resource) {
-		return AccessToken{}, ErrUnacknowledgedResourceFound
+	if resource != "" {
+		if !slices.Contains(logtoClient.logtoConfig.Resources, resource) {
+			return AccessToken{}, ErrUnacknowledgedResourceFound
+		}
 	}
 
 	accessTokenKey := buildAccessTokenKey([]string{}, resource)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -19,9 +19,7 @@ func TestGetAccessTokenShouldReturnAccessTokenAccessTokenInTokenMap(t *testing.T
 	}
 
 	logtoClient := NewLogtoClient(
-		&LogtoConfig{
-			Resources: []string{""},
-		},
+		&LogtoConfig{},
 		&TestStorage{
 			data: map[string]string{
 				StorageKeyIdToken: "id token",
@@ -39,9 +37,7 @@ func TestGetAccessTokenShouldReturnAccessTokenAccessTokenInTokenMap(t *testing.T
 
 func TestGetAccessTokenShouldReturnNotAuthenticatedErrIfNoIdTokenAvailable(t *testing.T) {
 	logtoClient := NewLogtoClient(
-		&LogtoConfig{
-			Resources: []string{""},
-		},
+		&LogtoConfig{},
 		&TestStorage{
 			data: map[string]string{
 				StorageKeyIdToken: "",
@@ -95,9 +91,7 @@ func TestGetAccessTokenShouldReturnFetchedAccessTokenAndUpdateLocalAccessTokenIf
 	defer patchesForVerifyIdToken.Reset()
 
 	logtoClient := NewLogtoClient(
-		&LogtoConfig{
-			Resources: []string{""},
-		},
+		&LogtoConfig{},
 		&TestStorage{
 			data: map[string]string{
 				StorageKeyIdToken:      "id token",

--- a/client/handle_sign_in_callback_test.go
+++ b/client/handle_sign_in_callback_test.go
@@ -64,9 +64,7 @@ func TestHandleSignInCallbackShouldHandleCallbackCorrectly(t *testing.T) {
 		},
 	}
 
-	logtoClient := NewLogtoClient(&LogtoConfig{
-		Resources: []string{""},
-	}, storage)
+	logtoClient := NewLogtoClient(&LogtoConfig{}, storage)
 
 	signInCallbackRequest, createSignInCallbackRequestErr := http.NewRequest("GET", "https://example.com/sign-in-callback", nil)
 	assert.Nil(t, createSignInCallbackRequestErr)

--- a/client/helper_test.go
+++ b/client/helper_test.go
@@ -66,9 +66,7 @@ func TestFetchOidcConfigShouldReturnExpectedOidcConfig(t *testing.T) {
 func TestLoadAccessTokenMapShouldLoadAccessTokenMapFromStorage(t *testing.T) {
 	expiresAt := time.Now().Unix() + 60
 
-	logtoConfig := &LogtoConfig{
-		Resources: []string{"testResource"},
-	}
+	logtoConfig := &LogtoConfig{}
 
 	testStorage := &TestStorage{
 		data: map[string]string{
@@ -152,10 +150,7 @@ func TestVerifyAndSaveTokenResponseShouldSaveToken(t *testing.T) {
 
 	defer patchesForVerifyIdToken.Reset()
 
-	logtoClient := NewLogtoClient(&LogtoConfig{
-		// TODO: do not check granted resource if resource is empty
-		Resources: []string{""},
-	}, &TestStorage{
+	logtoClient := NewLogtoClient(&LogtoConfig{}, &TestStorage{
 		data: map[string]string{},
 	})
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detail PR description below -->
fix(client): skip resource check in `GetAccessToken` when resource is empty string

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT
