### PR TITLE
chore: increase commit body max line length

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -39,6 +39,7 @@ jobs:
             rules: {
               'type-enum': [2, 'always', [...rules['type-enum'][2], 'release']],
               'scope-enum': [2, 'always', ['core', 'client', 'gin-sample', 'deps']],
+              'body-max-line-length': [2, 'always', 200],
             },
           };
           EEE


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Increase commit body max line length since the go lib hash is a long string and will cause the commitlint task to fail.
<img width="809" alt="image" src="https://user-images.githubusercontent.com/10806653/231088419-0117bd33-6589-40a4-9eb0-0e3b52dc99ed.png">


<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
CI.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
