### PR TITLE
fix(client): remove id token for sign out

### DIFF
--- a/client/sign_out.go
+++ b/client/sign_out.go
@@ -5,11 +5,6 @@ import (
 )
 
 func (logtoClient *LogtoClient) SignOut(postLogoutRedirectUri string) (string, error) {
-	idToken := logtoClient.GetIdToken()
-	if idToken == "" {
-		return "", ErrNotAuthenticated
-	}
-
 	refreshToken := logtoClient.GetRefreshToken()
 
 	logtoClient.accessTokenMap = make(map[string]AccessToken)


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Remove "idToken" check for "sign out":
The problem is that, if the "idToken" is already expired, the sign out process will fail, then the user is not able to sign out and sign in again.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
