### PR TITLE
fix: ensure the basic auth header is included when fetching token

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -33,7 +33,7 @@ type LogtoClient struct {
 
 func NewLogtoClient(config *LogtoConfig, storage Storage) *LogtoClient {
 	logtoClient := LogtoClient{
-		httpClient:     createHttpClient(config),
+		httpClient:     &http.Client{},
 		logtoConfig:    config,
 		storage:        storage,
 		accessTokenMap: make(map[string]AccessToken),
@@ -109,6 +109,7 @@ func (logtoClient *LogtoClient) GetAccessToken(resource string) (AccessToken, er
 	refreshedToken, refreshTokenErr := core.FetchTokenByRefreshToken(logtoClient.httpClient, &core.FetchTokenByRefreshTokenOptions{
 		TokenEndpoint: oidcConfig.TokenEndpoint,
 		ClientId:      logtoClient.logtoConfig.AppId,
+		ClientSecret:  logtoClient.logtoConfig.AppSecret,
 		RefreshToken:  refreshToken,
 		Resource:      resource,
 		Scopes:        []string{},

--- a/client/handle_sign_in_callback.go
+++ b/client/handle_sign_in_callback.go
@@ -33,6 +33,7 @@ func (logtoClient *LogtoClient) HandleSignInCallback(request *http.Request) erro
 		Code:          code,
 		CodeVerifier:  signInSession.CodeVerifier,
 		ClientId:      logtoClient.logtoConfig.AppId,
+		ClientSecret:  logtoClient.logtoConfig.AppSecret,
 		RedirectUri:   signInSession.RedirectUri,
 	})
 

--- a/client/util.go
+++ b/client/util.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"net/http"
-	"net/url"
 	"sort"
 	"strings"
 
@@ -23,21 +22,6 @@ func getRequestProtocol(request *http.Request) string {
 		return strings.ToLower(strings.Trim(extractedProto, " "))
 	}
 	return "http"
-}
-
-func createHttpClient(logtoConfig *LogtoConfig) *http.Client {
-	defaultTransport := http.DefaultTransport.(*http.Transport)
-	customTransport := defaultTransport.Clone()
-	customTransport.Proxy = func(req *http.Request) (*url.URL, error) {
-		if logtoConfig.AppSecret != "" {
-			req.SetBasicAuth(logtoConfig.AppId, logtoConfig.AppSecret)
-		}
-		return defaultTransport.Proxy(req)
-	}
-
-	return &http.Client{
-		Transport: customTransport,
-	}
 }
 
 func buildAccessTokenKey(scopes []string, resource string) string {

--- a/client/util_test.go
+++ b/client/util_test.go
@@ -52,17 +52,6 @@ func TestGetOriginRequestUrlShouldReturnCorrectUrlWithTlsConnection(t *testing.T
 	assert.Equal(t, "https://"+testRequestUri, originUrl)
 }
 
-func TestCreateHttpClientShouldReturnHttpClientWithCustomTransportCompletion(t *testing.T) {
-	logtoConfig := &LogtoConfig{
-		AppId:     "AppId",
-		AppSecret: "AppSecret",
-	}
-
-	logtoHttpClient := createHttpClient(logtoConfig)
-
-	assert.NotEqual(t, http.DefaultTransport, logtoHttpClient.Transport)
-}
-
 func TestBuildAccessTokenKeyShouldBuildCorrectly(t *testing.T) {
 	tests := []struct {
 		scopes   []string

--- a/core/fetch_token.go
+++ b/core/fetch_token.go
@@ -11,6 +11,7 @@ type FetchTokenByAuthorizationCodeOptions struct {
 	Code          string
 	CodeVerifier  string
 	ClientId      string
+	ClientSecret  string
 	RedirectUri   string
 	Resource      string
 }
@@ -27,8 +28,19 @@ func FetchTokenByAuthorizationCode(client *http.Client, options *FetchTokenByAut
 	if options.Resource != "" {
 		values.Add("resource", options.Resource)
 	}
+	request, createRequestErr := http.NewRequest("POST", options.TokenEndpoint, strings.NewReader(values.Encode()))
 
-	response, requestErr := client.PostForm(options.TokenEndpoint, values)
+	if createRequestErr != nil {
+		return RefreshTokenResponse{}, createRequestErr
+	}
+
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	if options.ClientSecret != "" {
+		request.SetBasicAuth(options.ClientId, options.ClientSecret)
+	}
+
+	response, requestErr := client.Do(request)
 
 	if requestErr != nil {
 		return CodeTokenResponse{}, requestErr
@@ -49,6 +61,7 @@ func FetchTokenByAuthorizationCode(client *http.Client, options *FetchTokenByAut
 type FetchTokenByRefreshTokenOptions struct {
 	TokenEndpoint string
 	ClientId      string
+	ClientSecret  string
 	RefreshToken  string
 	Resource      string
 	Scopes        []string
@@ -69,7 +82,19 @@ func FetchTokenByRefreshToken(client *http.Client, options *FetchTokenByRefreshT
 		values.Add("scope", strings.Join(options.Scopes, " "))
 	}
 
-	response, requestErr := client.PostForm(options.TokenEndpoint, values)
+	request, createRequestErr := http.NewRequest("POST", options.TokenEndpoint, strings.NewReader(values.Encode()))
+
+	if createRequestErr != nil {
+		return RefreshTokenResponse{}, createRequestErr
+	}
+
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	if options.ClientSecret != "" {
+		request.SetBasicAuth(options.ClientId, options.ClientSecret)
+	}
+
+	response, requestErr := client.Do(request)
 
 	if requestErr != nil {
 		return RefreshTokenResponse{}, requestErr

--- a/core/fetch_token_test.go
+++ b/core/fetch_token_test.go
@@ -34,6 +34,7 @@ func TestFetchTokenByAuthorizationCode(t *testing.T) {
 		Code:          "code",
 		CodeVerifier:  "codeVerifier",
 		ClientId:      "clientId",
+		ClientSecret:  "clientSecret",
 		RedirectUri:   "redirectUri",
 		Resource:      "resource",
 	}
@@ -71,6 +72,7 @@ func TestFetchTokenByRefreshToken(t *testing.T) {
 	options := &FetchTokenByRefreshTokenOptions{
 		TokenEndpoint: tokenEndpoint,
 		ClientId:      "clientId",
+		ClientSecret:  "clientSecret",
 		RefreshToken:  "refresh_token",
 		Resource:      "resource",
 		Scopes:        []string{"openid", "offline_access"},


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
In the old implementation, we used a custom transport to add a basic auth header for logto HTTP requests.

However, when the requested server address uses HTTPS and supports HTTP/2, our `customTransport` will not be invoked. Therefore, it is unreliable to modify the request content within `customTransport`.

`customTransport` is mainly used for setting up proxies rather than modifying request content.

Therefore, we need to manually set the basic auth header before initiating the request.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
Test locally & UT

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] docs

OR

- [x] This PR is not applicable for the checklist
