### PR TITLE
refactor: remove redundant HTTP body close Operations

### DIFF
--- a/core/parse_response.go
+++ b/core/parse_response.go
@@ -8,7 +8,6 @@ import (
 )
 
 func parseDataFromResponse(response *http.Response, dest interface{}) error {
-	defer response.Body.Close()
 	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return err


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
Removed redundant HTTP body close operations from the function. Since every caller of this function handles the closing operation, there's no need for duplicate closures. While this wouldn't introduce any additional issues, adhering to a consistent closing operation standard is a better practice.
<!-- Provide detailed PR description below -->


<!-- MANDATORY -->
```
go test -gcflags=all=-l -count=1 -cover ./...<!-- How did you test this PR? -->
?       github.com/logto-io/go/gin-sample       [no test files]
ok      github.com/logto-io/go/client   0.587s  coverage: 84.1% of statements
ok      github.com/logto-io/go/core     1.051s  coverage: 84.7% of statements
```

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
