### PR TITLE
chore: always run commit lint

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -13,7 +13,6 @@ concurrency:
 
 jobs:
   lint-commits:
-    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
fix(ci): always run commit lint or the publish action will failed since the commit lint job is skipped.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
CI