### PR TITLE
chore: allow skip jobs when publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,3 +56,4 @@ jobs:
           branch: master
           tags: true
           timeout: 20
+          acceptable_conclusions: success,skipped


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Allow skip jobs when publishing since when publishing, we will skip the commitlint check, and this will cause the publish action to fail.