### PR TITLE
refactor: remove redundant HTTP body close Operations

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -13,6 +13,7 @@ concurrency:
 
 jobs:
   lint-commits:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -13,7 +13,6 @@ concurrency:
 
 jobs:
   lint-commits:
-    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,3 +56,4 @@ jobs:
           branch: master
           tags: true
           timeout: 20
+          acceptable_conclusions: success,skipped

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,25 @@
 # Changelog
 
-## [1.0.3](https://github.com/logto-io/go/compare/v1.0.3...1.0.3) (2023-05-29)
+## [v1.0.4](https://github.com/logto-io/go/compare/v1.0.3...v1.0.4) (2023-12-01)
+
+### Feat
+
+* support organizations ([#89](https://github.com/logto-io/go/issues/89))
+* **core:** add organization data to userinfo response ([#91](https://github.com/logto-io/go/issues/91))
+
+### Fix
+
+* **deps:** update module github.com/jarcoal/httpmock to v1.3.1 ([#80](https://github.com/logto-io/go/issues/80))
+* **deps:** update golang.org/x/exp digest to 6522937 ([#79](https://github.com/logto-io/go/issues/79))
+* **deps:** update module github.com/stretchr/testify to v1.8.4 ([#73](https://github.com/logto-io/go/issues/73))
+* **deps:** update module github.com/agiledragon/gomonkey/v2 to v2.10.1 ([#69](https://github.com/logto-io/go/issues/69))
+* **deps:** update golang.org/x/exp digest to 2e198f4 ([#68](https://github.com/logto-io/go/issues/68))
 
 
-## [v1.0.3](https://github.com/logto-io/go/compare/v1.0.2...v1.0.3) (2023-05-29)
+## [v1.0.3](https://github.com/logto-io/go/compare/1.0.3...v1.0.3) (2023-05-29)
+
+
+## [1.0.3](https://github.com/logto-io/go/compare/v1.0.2...1.0.3) (2023-05-29)
 
 ### Fix
 

--- a/client/client.go
+++ b/client/client.go
@@ -5,18 +5,10 @@ import (
 	"time"
 
 	"golang.org/x/exp/slices"
+	"gopkg.in/square/go-jose.v2/jwt"
 
 	"github.com/logto-io/go/core"
 )
-
-type LogtoConfig struct {
-	Endpoint  string
-	AppId     string
-	AppSecret string
-	Scopes    []string
-	Resources []string
-	Prompt    string
-}
 
 type AccessToken struct {
 	Token     string `json:"token"`
@@ -32,6 +24,7 @@ type LogtoClient struct {
 }
 
 func NewLogtoClient(config *LogtoConfig, storage Storage) *LogtoClient {
+	config.normalized()
 	logtoClient := LogtoClient{
 		httpClient:     &http.Client{},
 		logtoConfig:    config,
@@ -71,12 +64,35 @@ func (logtoClient *LogtoClient) GetIdTokenClaims() (core.IdTokenClaims, error) {
 	return core.DecodeIdToken(logtoClient.GetIdToken())
 }
 
+func (logtoClient *LogtoClient) GetOrganizationTokenClaims(organizationId string) (core.OrganizationAccessTokenClaims, error) {
+	token, getTokenErr := logtoClient.GetOrganizationToken(organizationId)
+
+	if getTokenErr != nil {
+		return core.OrganizationAccessTokenClaims{}, getTokenErr
+	}
+
+	jwtObject, parseTokenErr := jwt.ParseSigned(token.Token)
+
+	if parseTokenErr != nil {
+		return core.OrganizationAccessTokenClaims{}, parseTokenErr
+	}
+
+	var claims core.OrganizationAccessTokenClaims
+	claimsErr := jwtObject.UnsafeClaimsWithoutVerification(&claims)
+
+	if claimsErr != nil {
+		return core.OrganizationAccessTokenClaims{}, claimsErr
+	}
+
+	return claims, claimsErr
+}
+
 func (logtoClient *LogtoClient) SaveAccessToken(key string, accessToken AccessToken) {
 	logtoClient.accessTokenMap[key] = accessToken
 	logtoClient.persistAccessTokenMap()
 }
 
-func (logtoClient *LogtoClient) GetAccessToken(resource string) (AccessToken, error) {
+func (logtoClient *LogtoClient) getAccessToken(resource string, organizationId string) (AccessToken, error) {
 	if !logtoClient.IsAuthenticated() {
 		return AccessToken{}, ErrNotAuthenticated
 	}
@@ -87,7 +103,7 @@ func (logtoClient *LogtoClient) GetAccessToken(resource string) (AccessToken, er
 		}
 	}
 
-	accessTokenKey := buildAccessTokenKey([]string{}, resource)
+	accessTokenKey := buildAccessTokenKey([]string{}, resource, organizationId)
 	if accessToken, ok := logtoClient.accessTokenMap[accessTokenKey]; ok {
 		if accessToken.ExpiresAt > time.Now().Unix() {
 			return accessToken, nil
@@ -107,12 +123,13 @@ func (logtoClient *LogtoClient) GetAccessToken(resource string) (AccessToken, er
 	}
 
 	refreshedToken, refreshTokenErr := core.FetchTokenByRefreshToken(logtoClient.httpClient, &core.FetchTokenByRefreshTokenOptions{
-		TokenEndpoint: oidcConfig.TokenEndpoint,
-		ClientId:      logtoClient.logtoConfig.AppId,
-		ClientSecret:  logtoClient.logtoConfig.AppSecret,
-		RefreshToken:  refreshToken,
-		Resource:      resource,
-		Scopes:        []string{},
+		TokenEndpoint:  oidcConfig.TokenEndpoint,
+		ClientId:       logtoClient.logtoConfig.AppId,
+		ClientSecret:   logtoClient.logtoConfig.AppSecret,
+		RefreshToken:   refreshToken,
+		Resource:       resource,
+		Scopes:         []string{},
+		OrganizationId: organizationId,
 	})
 
 	if refreshTokenErr != nil {
@@ -128,6 +145,7 @@ func (logtoClient *LogtoClient) GetAccessToken(resource string) (AccessToken, er
 	verificationErr := logtoClient.verifyAndSaveTokenResponse(
 		refreshedToken.IdToken,
 		refreshedToken.RefreshToken,
+		accessTokenKey,
 		refreshedAccessToken,
 		&oidcConfig,
 	)
@@ -137,6 +155,18 @@ func (logtoClient *LogtoClient) GetAccessToken(resource string) (AccessToken, er
 	}
 
 	return refreshedAccessToken, nil
+}
+
+func (logtoClient *LogtoClient) GetAccessToken(resource string) (AccessToken, error) {
+	return logtoClient.getAccessToken(resource, "")
+}
+
+func (logtoClient *LogtoClient) GetOrganizationToken(organizationId string) (AccessToken, error) {
+	if !slices.Contains(logtoClient.logtoConfig.Scopes, core.UserScopeOrganizations) {
+		return AccessToken{}, ErrMissingScopeOrganizations
+	}
+
+	return logtoClient.getAccessToken("", organizationId)
 }
 
 func (logtoClient *LogtoClient) FetchUserInfo() (core.UserInfoResponse, error) {

--- a/client/errors.go
+++ b/client/errors.go
@@ -5,4 +5,5 @@ import "errors"
 var (
 	ErrNotAuthenticated            = errors.New("not authenticated")
 	ErrUnacknowledgedResourceFound = errors.New("unacknowledged resource found")
+	ErrMissingScopeOrganizations   = errors.New("missing 'urn:logto:scope:organizations' scope")
 )

--- a/client/handle_sign_in_callback.go
+++ b/client/handle_sign_in_callback.go
@@ -49,9 +49,12 @@ func (logtoClient *LogtoClient) HandleSignInCallback(request *http.Request) erro
 		ExpiresAt: time.Now().Unix() + int64(codeTokenResponse.ExpireIn),
 	}
 
+	// - Treat `scopes` as `empty` to construct the default access token key
+	accessTokenKey := buildAccessTokenKey([]string{}, "", "")
 	verificationErr := logtoClient.verifyAndSaveTokenResponse(
 		codeTokenResponse.IdToken,
 		codeTokenResponse.RefreshToken,
+		accessTokenKey,
 		accessToken,
 		&oidcConfig,
 	)

--- a/client/helper.go
+++ b/client/helper.go
@@ -69,6 +69,7 @@ func (logtoClient *LogtoClient) createRemoteJwks(jwksUri string) (*jose.JSONWebK
 func (logtoClient *LogtoClient) verifyAndSaveTokenResponse(
 	idToken string,
 	refreshToken string,
+	accessTokenKey string,
 	accessToken AccessToken,
 	oidcConfig *core.OidcConfigResponse,
 ) error {
@@ -87,12 +88,6 @@ func (logtoClient *LogtoClient) verifyAndSaveTokenResponse(
 	}
 
 	logtoClient.SetRefreshToken(refreshToken)
-
-	// Note
-	// - Treat `scopes` as `empty` to construct the default access token key
-	// for we do not support custom scopes in V1
-	resource := getResourceFromAccessToken(accessToken.Token)
-	accessTokenKey := buildAccessTokenKey([]string{}, resource)
 
 	logtoClient.SaveAccessToken(accessTokenKey, accessToken)
 

--- a/client/helper_test.go
+++ b/client/helper_test.go
@@ -156,9 +156,10 @@ func TestVerifyAndSaveTokenResponseShouldSaveToken(t *testing.T) {
 
 	testIdToken := "idToken"
 	testRefreshToken := "refreshToken"
+	testAccessTokenKey := "@"
 	testAccessToken := AccessToken{Token: "testToken", Scope: "read", ExpiresAt: time.Now().Unix() + 60}
 
-	verifyAndSaveTokenResponseErr := logtoClient.verifyAndSaveTokenResponse(testIdToken, testRefreshToken, testAccessToken, &core.OidcConfigResponse{})
+	verifyAndSaveTokenResponseErr := logtoClient.verifyAndSaveTokenResponse(testIdToken, testRefreshToken, testAccessTokenKey, testAccessToken, &core.OidcConfigResponse{})
 	assert.Nil(t, verifyAndSaveTokenResponseErr)
 
 	assert.Equal(t, testIdToken, logtoClient.GetIdToken())

--- a/client/logto_config.go
+++ b/client/logto_config.go
@@ -1,0 +1,31 @@
+package client
+
+import (
+	"github.com/logto-io/go/core"
+	"golang.org/x/exp/slices"
+)
+
+type LogtoConfig struct {
+	Endpoint  string
+	AppId     string
+	AppSecret string
+	Scopes    []string
+	Resources []string
+	Prompt    string
+}
+
+/**
+ * Normalize the Logto client configuration per the following rules:
+ *
+ * - Add default scopes (`openid`, `offline_access` and `profile`) if not provided.
+ * - Add `ReservedResource.Organization` to resources if `UserScope.Organizations` is included in scopes.
+ */
+func (logtoConfig *LogtoConfig) normalized() {
+	for _, defaultScope := range core.DefaultScopes {
+		logtoConfig.Scopes = core.AppendIfNotExisted(logtoConfig.Scopes, defaultScope)
+	}
+
+	if slices.Contains(logtoConfig.Scopes, core.UserScopeOrganizations) {
+		logtoConfig.Resources = core.AppendIfNotExisted(logtoConfig.Resources, core.ReservedResourceOrganization)
+	}
+}

--- a/client/util.go
+++ b/client/util.go
@@ -24,10 +24,16 @@ func getRequestProtocol(request *http.Request) string {
 	return "http"
 }
 
-func buildAccessTokenKey(scopes []string, resource string) string {
+func buildAccessTokenKey(scopes []string, resource string, organizationId string) string {
 	sort.Strings(scopes)
 	scopesPart := strings.Join(scopes, " ")
-	return scopesPart + "@" + resource
+
+	organizationPart := ""
+	if organizationId != "" {
+		organizationPart = "#" + organizationId
+	}
+
+	return scopesPart + "@" + resource + organizationPart
 }
 
 func getResourceFromAccessToken(accessToken string) string {

--- a/client/util_test.go
+++ b/client/util_test.go
@@ -67,7 +67,7 @@ func TestBuildAccessTokenKeyShouldBuildCorrectly(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		accessTokenKey := buildAccessTokenKey(test.scopes, test.resource)
+		accessTokenKey := buildAccessTokenKey(test.scopes, test.resource, "")
 		assert.Equal(t, test.result, accessTokenKey)
 	}
 }

--- a/core/constants.go
+++ b/core/constants.go
@@ -6,9 +6,24 @@ var (
 )
 
 var (
-	UserScopeProfile    = "profile"
-	UserScopeEmail      = "email"
-	UserScopePhone      = "phone"
-	UserScopeCustomData = "custom_data"
-	UserScopeIdentities = "identities"
+	ReservedResourceOrganization = "urn:logto:resource:organizations"
+)
+
+var (
+	UserScopeProfile           = "profile"
+	UserScopeEmail             = "email"
+	UserScopePhone             = "phone"
+	UserScopeCustomData        = "custom_data"
+	UserScopeIdentities        = "identities"
+	UserScopeRoles             = "roles"
+	UserScopeOrganizations     = "urn:logto:scope:organizations"
+	UserScopeOrganizationRoles = "urn:logto:scope:organization_roles"
+)
+
+var (
+	DefaultScopes = []string{
+		ReservedScopeOpenId,
+		ReservedScopeOfflineAccess,
+		UserScopeProfile,
+	}
 )

--- a/core/decode_id_token_test.go
+++ b/core/decode_id_token_test.go
@@ -18,7 +18,7 @@ func TestDecodeIdTokenShouldGetExpectedIdTokenClaims(t *testing.T) {
 		AtHash:   "1234567890",
 		Username: "1234567890",
 		Name:     "1234567890",
-		Avatar:   "1234567890",
+		Picture:  "picture",
 	}
 
 	idToken, _, generateError := generateRsaSigningTestTokenAndCorrespondJwks(testClaims)

--- a/core/fetch_token.go
+++ b/core/fetch_token.go
@@ -59,12 +59,13 @@ func FetchTokenByAuthorizationCode(client *http.Client, options *FetchTokenByAut
 }
 
 type FetchTokenByRefreshTokenOptions struct {
-	TokenEndpoint string
-	ClientId      string
-	ClientSecret  string
-	RefreshToken  string
-	Resource      string
-	Scopes        []string
+	TokenEndpoint  string
+	ClientId       string
+	ClientSecret   string
+	RefreshToken   string
+	Resource       string
+	Scopes         []string
+	OrganizationId string
 }
 
 func FetchTokenByRefreshToken(client *http.Client, options *FetchTokenByRefreshTokenOptions) (RefreshTokenResponse, error) {
@@ -80,6 +81,10 @@ func FetchTokenByRefreshToken(client *http.Client, options *FetchTokenByRefreshT
 
 	if len(options.Scopes) > 0 {
 		values.Add("scope", strings.Join(options.Scopes, " "))
+	}
+
+	if options.OrganizationId != "" {
+		values.Add("organization_id", options.OrganizationId)
 	}
 
 	request, createRequestErr := http.NewRequest("POST", options.TokenEndpoint, strings.NewReader(values.Encode()))

--- a/core/fetch_token_test.go
+++ b/core/fetch_token_test.go
@@ -70,12 +70,13 @@ func TestFetchTokenByRefreshToken(t *testing.T) {
 
 	client := &http.Client{}
 	options := &FetchTokenByRefreshTokenOptions{
-		TokenEndpoint: tokenEndpoint,
-		ClientId:      "clientId",
-		ClientSecret:  "clientSecret",
-		RefreshToken:  "refresh_token",
-		Resource:      "resource",
-		Scopes:        []string{"openid", "offline_access"},
+		TokenEndpoint:  tokenEndpoint,
+		ClientId:       "clientId",
+		ClientSecret:   "clientSecret",
+		RefreshToken:   "refresh_token",
+		Resource:       "resource",
+		Scopes:         []string{"openid", "offline_access"},
+		OrganizationId: "organizationId",
 	}
 
 	token, fetchError := FetchTokenByRefreshToken(client, options)

--- a/core/parse_response.go
+++ b/core/parse_response.go
@@ -8,7 +8,6 @@ import (
 )
 
 func parseDataFromResponse(response *http.Response, dest interface{}) error {
-	defer response.Body.Close()
 	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return err

--- a/core/type.go
+++ b/core/type.go
@@ -34,13 +34,31 @@ type UserInfoResponse struct {
 }
 
 type IdTokenClaims struct {
+	Iss                 string   `json:"iss"`
+	Sub                 string   `json:"sub"`
+	Aud                 string   `json:"aud"`
+	Exp                 int64    `json:"exp"`
+	Iat                 int64    `json:"iat"`
+	AtHash              string   `json:"at_hash"`
+	Name                string   `json:"name"`
+	Username            string   `json:"username"`
+	Picture             string   `json:"picture"`
+	Email               string   `json:"email"`
+	EmailVerified       bool     `json:"email_verified"`
+	PhoneNumber         string   `json:"phone_number"`
+	PhoneNumberVerified bool     `json:"phone_number_verified"`
+	Roles               []string `json:"roles"`
+	Organizations       []string `json:"organizations"`
+	OrganizationRoles   []string `json:"organization_roles"`
+}
+
+type OrganizationAccessTokenClaims struct {
+	Iss      string `json:"iss"`
 	Sub      string `json:"sub"`
 	Aud      string `json:"aud"`
 	Exp      int64  `json:"exp"`
 	Iat      int64  `json:"iat"`
-	Iss      string `json:"iss"`
-	AtHash   string `json:"at_hash"`
-	Username string `json:"username"`
-	Name     string `json:"name"`
-	Avatar   string `json:"avatar"`
+	ClientId string `json:"client_id"`
+	Jti      string `json:"jti"`
+	Scope    string `json:"scope"`
 }

--- a/core/type.go
+++ b/core/type.go
@@ -20,6 +20,12 @@ type CodeTokenResponse struct {
 
 type RefreshTokenResponse = CodeTokenResponse
 
+type Organization struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
 type UserInfoResponse struct {
 	Sub                 string                 `json:"sub"`
 	Name                string                 `json:"name"`
@@ -31,6 +37,7 @@ type UserInfoResponse struct {
 	PhoneNumberVerified bool                   `json:"phone_number_verified"`
 	CustomData          map[string]interface{} `json:"custom_data"`
 	Identities          map[string]interface{} `json:"identities"`
+	OrganizationData    []Organization         `json:"organization_data"`
 }
 
 type IdTokenClaims struct {

--- a/core/util.go
+++ b/core/util.go
@@ -1,0 +1,11 @@
+package core
+
+func AppendIfNotExisted(targets []string, item string) []string {
+	for _, s := range targets {
+		if s == item {
+			return targets
+		}
+	}
+
+	return append(targets, item)
+}

--- a/core/verify_id_token_test.go
+++ b/core/verify_id_token_test.go
@@ -22,7 +22,7 @@ func TestVerifyIdToken(t *testing.T) {
 		AtHash:   "1234567890",
 		Username: "1234567890",
 		Name:     "1234567890",
-		Avatar:   "1234567890",
+		Picture:  "1234567890",
 	}
 
 	idToken, jwks, generateError := generateRsaSigningTestTokenAndCorrespondJwks(idTokenClaims)
@@ -49,7 +49,7 @@ func TestVerifyIdTokenShouldSupportES512FormatJwks(t *testing.T) {
 		AtHash:   "1234567890",
 		Username: "1234567890",
 		Name:     "1234567890",
-		Avatar:   "1234567890",
+		Picture:  "1234567890",
 	}
 
 	idToken, jwks, generateError := generateEcdsaSigningTestTokenAndCorrespondJwks(idTokenClaims)
@@ -73,7 +73,7 @@ func TestVerifyIdTokenShouldReturnErrorIfIssuedAtIsInThePast(t *testing.T) {
 		AtHash:   "1234567890",
 		Username: "1234567890",
 		Name:     "1234567890",
-		Avatar:   "1234567890",
+		Picture:  "1234567890",
 	}
 
 	idToken, jwks, generateError := generateRsaSigningTestTokenAndCorrespondJwks(idTokenClaims)
@@ -97,7 +97,7 @@ func TestVerifyIdTokenShouldReturnErrorIfIssuedAtIsInTheFuture(t *testing.T) {
 		AtHash:   "1234567890",
 		Username: "1234567890",
 		Name:     "1234567890",
-		Avatar:   "1234567890",
+		Picture:  "1234567890",
 	}
 
 	idToken, jwks, generateError := generateRsaSigningTestTokenAndCorrespondJwks(idTokenClaims)
@@ -120,7 +120,7 @@ func TestVerifyIdTokenShouldReturnErrorIfExpired(t *testing.T) {
 		AtHash:   "1234567890",
 		Username: "1234567890",
 		Name:     "1234567890",
-		Avatar:   "1234567890",
+		Picture:  "1234567890",
 	}
 
 	idToken, jwks, generateError := generateRsaSigningTestTokenAndCorrespondJwks(idTokenClaims)
@@ -145,7 +145,7 @@ func TestVerifyIdTokenShouldReturnErrorIfIssuerIsNotMatched(t *testing.T) {
 		AtHash:   "1234567890",
 		Username: "1234567890",
 		Name:     "1234567890",
-		Avatar:   "1234567890",
+		Picture:  "1234567890",
 	}
 
 	idToken, jwks, generateError := generateRsaSigningTestTokenAndCorrespondJwks(idTokenClaims)
@@ -172,7 +172,7 @@ func TestVerifyIdTokenShouldReturnErrorIfAudienceIsNotMatched(t *testing.T) {
 		AtHash:   "1234567890",
 		Username: "1234567890",
 		Name:     "1234567890",
-		Avatar:   "1234567890",
+		Picture:  "1234567890",
 	}
 
 	idToken, jwks, generateError := generateRsaSigningTestTokenAndCorrespondJwks(idTokenClaims)

--- a/gin-sample/main.go
+++ b/gin-sample/main.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"log"
 	"net/http"
 
 	"github.com/gin-contrib/sessions"
 	"github.com/gin-contrib/sessions/memstore"
 	"github.com/gin-gonic/gin"
+
 	"github.com/logto-io/go/client"
 )
 
@@ -144,5 +146,5 @@ func main() {
 		ctx.Data(http.StatusOK, ContentTypeHtml, []byte(unauthorizedPage))
 	})
 
-	router.Run("0.0.0:8080")
+	log.Fatal(router.Run("0.0.0:8080"))
 }


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->

Removed redundant HTTP body close operations from the function. Since every caller of this function handles the closing operation, there's no need for duplicate closures. While this wouldn't introduce any additional issues, adhering to a consistent closing operation standard is a better practice.



<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->


```bash
go test -gcflags=all=-l -count=1 -cover ./...
?       github.com/logto-io/go/gin-sample       [no test files]
ok      github.com/logto-io/go/client   0.587s  coverage: 84.1% of statements
ok      github.com/logto-io/go/core     1.051s  coverage: 84.7% of statements
```

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

- [ ] `.changeset`
- [x] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments
