### PR TITLE
chore: prepare v2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,12 +52,12 @@ jobs:
       - name: Run Core Unit Tests And Generate Coverage Report
         run: |
           mkdir -p ./build/core/test
-          go test github.com/logto-io/go/core -coverprofile=./build/core/test/coverage.out -covermode=atomic -gcflags=all=-l
+          go test github.com/logto-io/go/v2/core -coverprofile=./build/core/test/coverage.out -covermode=atomic -gcflags=all=-l
 
       - name: Run Client Unit Tests And Generate Coverage Report
         run: |
           mkdir -p ./build/client/test
-          go test github.com/logto-io/go/client -coverprofile=./build/client/test/coverage.out -covermode=atomic -gcflags=all=-l
+          go test github.com/logto-io/go/v2/client -coverprofile=./build/client/test/coverage.out -covermode=atomic -gcflags=all=-l
 
       - name: Upload Core Coverage Report
         uses: codecov/codecov-action@v4

--- a/client/client.go
+++ b/client/client.go
@@ -6,7 +6,7 @@ import (
 
 	"golang.org/x/exp/slices"
 
-	"github.com/logto-io/go/core"
+	"github.com/logto-io/go/v2/core"
 )
 
 type AccessToken struct {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/agiledragon/gomonkey/v2"
 	"github.com/go-jose/go-jose/v4"
-	"github.com/logto-io/go/core"
+	"github.com/logto-io/go/v2/core"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/client/handle_sign_in_callback.go
+++ b/client/handle_sign_in_callback.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/logto-io/go/core"
+	"github.com/logto-io/go/v2/core"
 )
 
 func (logtoClient *LogtoClient) HandleSignInCallback(request *http.Request) error {

--- a/client/handle_sign_in_callback_test.go
+++ b/client/handle_sign_in_callback_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/agiledragon/gomonkey/v2"
 	"github.com/go-jose/go-jose/v4"
-	"github.com/logto-io/go/core"
+	"github.com/logto-io/go/v2/core"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/client/helper.go
+++ b/client/helper.go
@@ -5,7 +5,7 @@ import (
 	"net/url"
 
 	"github.com/go-jose/go-jose/v4"
-	"github.com/logto-io/go/core"
+	"github.com/logto-io/go/v2/core"
 )
 
 func (logtoClient *LogtoClient) fetchOidcConfig() (core.OidcConfigResponse, error) {

--- a/client/helper_test.go
+++ b/client/helper_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/agiledragon/gomonkey/v2"
 	"github.com/go-jose/go-jose/v4"
 	"github.com/jarcoal/httpmock"
-	"github.com/logto-io/go/core"
+	"github.com/logto-io/go/v2/core"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/client/logto_config.go
+++ b/client/logto_config.go
@@ -1,7 +1,7 @@
 package client
 
 import (
-	"github.com/logto-io/go/core"
+	"github.com/logto-io/go/v2/core"
 	"golang.org/x/exp/slices"
 )
 

--- a/client/sign_in.go
+++ b/client/sign_in.go
@@ -3,7 +3,7 @@ package client
 import (
 	"encoding/json"
 
-	"github.com/logto-io/go/core"
+	"github.com/logto-io/go/v2/core"
 )
 
 type SignInOptions struct {

--- a/client/sign_in_test.go
+++ b/client/sign_in_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/agiledragon/gomonkey/v2"
-	"github.com/logto-io/go/core"
+	"github.com/logto-io/go/v2/core"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/client/sign_out.go
+++ b/client/sign_out.go
@@ -1,7 +1,7 @@
 package client
 
 import (
-	"github.com/logto-io/go/core"
+	"github.com/logto-io/go/v2/core"
 )
 
 func (logtoClient *LogtoClient) SignOut(postLogoutRedirectUri string) (string, error) {

--- a/client/sign_out_test.go
+++ b/client/sign_out_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/agiledragon/gomonkey/v2"
-	"github.com/logto-io/go/core"
+	"github.com/logto-io/go/v2/core"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/client/util.go
+++ b/client/util.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/logto-io/go/core"
+	"github.com/logto-io/go/v2/core"
 )
 
 func GetOriginRequestUrl(request *http.Request) string {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/logto-io/go
+module github.com/logto-io/go/v2
 
 go 1.21
 


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
According to the go module polices, when upgrading go modules to v2, we need to use a v2 branch, this PR prepares v2 release for logto go sdk.

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
No need.

<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary TSDoc comments~~
