### PR TITLE
feat: support custom HTTP client injection

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -251,5 +251,5 @@ func (logtoClient *LogtoClient) FetchUserInfo() (core.UserInfoResponse, error) {
 		return core.UserInfoResponse{}, getAccessTokenErr
 	}
 
-	return core.FetchUserInfo(oidcConfig.UserinfoEndpoint, accessToken.Token)
+	return core.FetchUserInfoWithClient(logtoClient.httpClient, oidcConfig.UserinfoEndpoint, accessToken.Token)
 }

--- a/client/client.go
+++ b/client/client.go
@@ -31,6 +31,16 @@ type GetOrganizationTokenClaimsOptions struct {
 	OrganizationId string
 }
 
+// LogtoClientOption is a functional option for configuring LogtoClient
+type LogtoClientOption func(*LogtoClient)
+
+// WithHttpClient sets a custom HTTP client for the LogtoClient
+func WithHttpClient(client *http.Client) LogtoClientOption {
+	return func(c *LogtoClient) {
+		c.httpClient = client
+	}
+}
+
 type LogtoClient struct {
 	httpClient     *http.Client
 	logtoConfig    *LogtoConfig
@@ -38,13 +48,18 @@ type LogtoClient struct {
 	accessTokenMap map[string]AccessToken
 }
 
-func NewLogtoClient(config *LogtoConfig, storage Storage) *LogtoClient {
+func NewLogtoClient(config *LogtoConfig, storage Storage, opts ...LogtoClientOption) *LogtoClient {
 	config.normalized()
 	logtoClient := LogtoClient{
 		httpClient:     &http.Client{},
 		logtoConfig:    config,
 		storage:        storage,
 		accessTokenMap: make(map[string]AccessToken),
+	}
+
+	// Apply options
+	for _, opt := range opts {
+		opt(&logtoClient)
 	}
 
 	logtoClient.loadAccessTokenMap()

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -254,3 +254,59 @@ func TestFetchUserInfoShouldReturnErrorIfGetAccessTokenFailed(t *testing.T) {
 
 	assert.Equal(t, testGetAccessTokenErr, fetchUserInfoErr)
 }
+
+func TestNewLogtoClientShouldUseDefaultHttpClientWhenNoOptionsProvided(t *testing.T) {
+	logtoClient := NewLogtoClient(&LogtoConfig{}, &TestStorage{})
+	
+	assert.NotNil(t, logtoClient.httpClient)
+	// The default HTTP client should be a basic http.Client
+	assert.IsType(t, &http.Client{}, logtoClient.httpClient)
+}
+
+func TestNewLogtoClientShouldUseCustomHttpClientWhenWithHttpClientOptionProvided(t *testing.T) {
+	customClient := &http.Client{
+		Timeout: 10 * time.Second,
+	}
+	
+	logtoClient := NewLogtoClient(&LogtoConfig{}, &TestStorage{}, WithHttpClient(customClient))
+	
+	assert.NotNil(t, logtoClient.httpClient)
+	assert.Equal(t, customClient, logtoClient.httpClient)
+	assert.Equal(t, 10*time.Second, logtoClient.httpClient.Timeout)
+}
+
+func TestNewLogtoClientShouldApplyMultipleOptions(t *testing.T) {
+	customClient := &http.Client{
+		Timeout: 5 * time.Second,
+	}
+	
+	logtoClient := NewLogtoClient(&LogtoConfig{}, &TestStorage{}, 
+		WithHttpClient(customClient),
+		// Future options can be added here
+	)
+	
+	assert.NotNil(t, logtoClient.httpClient)
+	assert.Equal(t, customClient, logtoClient.httpClient)
+	assert.Equal(t, 5*time.Second, logtoClient.httpClient.Timeout)
+}
+
+func TestWithHttpClientShouldReturnValidOption(t *testing.T) {
+	customClient := &http.Client{
+		Timeout: 30 * time.Second,
+	}
+	
+	option := WithHttpClient(customClient)
+	
+	assert.NotNil(t, option)
+	
+	// Test that the option function works correctly
+	logtoClient := &LogtoClient{
+		httpClient: &http.Client{}, // Default client
+	}
+	
+	// Apply the option
+	option(logtoClient)
+	
+	assert.Equal(t, customClient, logtoClient.httpClient)
+	assert.Equal(t, 30*time.Second, logtoClient.httpClient.Timeout)
+}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -280,14 +280,24 @@ func TestNewLogtoClientShouldApplyMultipleOptions(t *testing.T) {
 		Timeout: 5 * time.Second,
 	}
 
+	// Create a mock second option for demonstration
+	var appliedSecondOption bool
+	mockSecondOption := func(client *LogtoClient) {
+		appliedSecondOption = true
+	}
+
 	logtoClient := NewLogtoClient(&LogtoConfig{}, &TestStorage{},
 		WithHttpClient(customClient),
-		// Future options can be added here
+		mockSecondOption,
 	)
 
+	// Verify first option (WithHttpClient) was applied
 	assert.NotNil(t, logtoClient.httpClient)
 	assert.Equal(t, customClient, logtoClient.httpClient)
 	assert.Equal(t, 5*time.Second, logtoClient.httpClient.Timeout)
+
+	// Verify second option was applied
+	assert.True(t, appliedSecondOption, "Second option should have been applied")
 }
 
 func TestWithHttpClientShouldReturnValidOption(t *testing.T) {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -181,7 +181,7 @@ func TestFetchUserInfoShouldReturnCorrectUserInfoResponse(t *testing.T) {
 	})
 	defer patchesForGetAccessToken.Reset()
 
-	patchesCoreFetchUserInfo := gomonkey.ApplyFunc(core.FetchUserInfo, func(userInfoEndpoint, accessToken string) (core.UserInfoResponse, error) {
+	patchesCoreFetchUserInfo := gomonkey.ApplyFunc(core.FetchUserInfoWithClient, func(client *http.Client, userInfoEndpoint, accessToken string) (core.UserInfoResponse, error) {
 		return testUserInfoResponse, nil
 	})
 	defer patchesCoreFetchUserInfo.Reset()
@@ -257,7 +257,7 @@ func TestFetchUserInfoShouldReturnErrorIfGetAccessTokenFailed(t *testing.T) {
 
 func TestNewLogtoClientShouldUseDefaultHttpClientWhenNoOptionsProvided(t *testing.T) {
 	logtoClient := NewLogtoClient(&LogtoConfig{}, &TestStorage{})
-	
+
 	assert.NotNil(t, logtoClient.httpClient)
 	// The default HTTP client should be a basic http.Client
 	assert.IsType(t, &http.Client{}, logtoClient.httpClient)
@@ -267,9 +267,9 @@ func TestNewLogtoClientShouldUseCustomHttpClientWhenWithHttpClientOptionProvided
 	customClient := &http.Client{
 		Timeout: 10 * time.Second,
 	}
-	
+
 	logtoClient := NewLogtoClient(&LogtoConfig{}, &TestStorage{}, WithHttpClient(customClient))
-	
+
 	assert.NotNil(t, logtoClient.httpClient)
 	assert.Equal(t, customClient, logtoClient.httpClient)
 	assert.Equal(t, 10*time.Second, logtoClient.httpClient.Timeout)
@@ -279,12 +279,12 @@ func TestNewLogtoClientShouldApplyMultipleOptions(t *testing.T) {
 	customClient := &http.Client{
 		Timeout: 5 * time.Second,
 	}
-	
-	logtoClient := NewLogtoClient(&LogtoConfig{}, &TestStorage{}, 
+
+	logtoClient := NewLogtoClient(&LogtoConfig{}, &TestStorage{},
 		WithHttpClient(customClient),
 		// Future options can be added here
 	)
-	
+
 	assert.NotNil(t, logtoClient.httpClient)
 	assert.Equal(t, customClient, logtoClient.httpClient)
 	assert.Equal(t, 5*time.Second, logtoClient.httpClient.Timeout)
@@ -294,19 +294,35 @@ func TestWithHttpClientShouldReturnValidOption(t *testing.T) {
 	customClient := &http.Client{
 		Timeout: 30 * time.Second,
 	}
-	
+
 	option := WithHttpClient(customClient)
-	
+
 	assert.NotNil(t, option)
-	
+
 	// Test that the option function works correctly
 	logtoClient := &LogtoClient{
 		httpClient: &http.Client{}, // Default client
 	}
-	
+
 	// Apply the option
 	option(logtoClient)
-	
+
 	assert.Equal(t, customClient, logtoClient.httpClient)
 	assert.Equal(t, 30*time.Second, logtoClient.httpClient.Timeout)
+}
+
+func TestLogtoClientShouldUseCustomHttpClientForFetchUserInfo(t *testing.T) {
+	customClient := &http.Client{
+		Timeout: 15 * time.Second,
+	}
+
+	logtoClient := NewLogtoClient(&LogtoConfig{}, &TestStorage{}, WithHttpClient(customClient))
+
+	// Verify that the client is using the custom HTTP client
+	assert.Equal(t, customClient, logtoClient.httpClient)
+	assert.Equal(t, 15*time.Second, logtoClient.httpClient.Timeout)
+
+	// This test verifies that the LogtoClient is configured with the custom HTTP client
+	// The actual FetchUserInfo will use this client when making HTTP requests
+	assert.NotNil(t, logtoClient.httpClient)
 }

--- a/core/fetch_user_info.go
+++ b/core/fetch_user_info.go
@@ -2,9 +2,10 @@ package core
 
 import "net/http"
 
-func FetchUserInfo(userInfoEndpoint, accessToken string) (UserInfoResponse, error) {
-	client := &http.Client{}
-
+// FetchUserInfoWithClient fetches user info using a custom HTTP client.
+// This function allows you to use a custom HTTP client for observability,
+// tracing, or other custom configurations.
+func FetchUserInfoWithClient(client *http.Client, userInfoEndpoint, accessToken string) (UserInfoResponse, error) {
 	request, createRequestErr := http.NewRequest("GET", userInfoEndpoint, nil)
 
 	if createRequestErr != nil {
@@ -29,4 +30,10 @@ func FetchUserInfo(userInfoEndpoint, accessToken string) (UserInfoResponse, erro
 	}
 
 	return userInfoResponse, nil
+}
+
+// FetchUserInfo fetches user info using the default HTTP client.
+// Deprecated: Use FetchUserInfoWithClient instead for better flexibility and observability support.
+func FetchUserInfo(userInfoEndpoint, accessToken string) (UserInfoResponse, error) {
+	return FetchUserInfoWithClient(&http.Client{}, userInfoEndpoint, accessToken)
 }

--- a/core/fetch_user_info_test.go
+++ b/core/fetch_user_info_test.go
@@ -2,13 +2,15 @@ package core
 
 import (
 	"encoding/json"
+	"net/http"
 	"testing"
+	"time"
 
 	"github.com/jarcoal/httpmock"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestFetchUserInfo(t *testing.T) {
+func TestFetchUserInfoWithClient(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 
@@ -36,7 +38,12 @@ func TestFetchUserInfo(t *testing.T) {
 		httpmock.NewStringResponder(200, mockResponse),
 	)
 
-	userInfoResponse, fetchError := FetchUserInfo(userInfoEndpoint, "accessToken")
+	// Test with custom HTTP client
+	customClient := &http.Client{
+		Timeout: 10 * time.Second,
+	}
+
+	userInfoResponse, fetchError := FetchUserInfoWithClient(customClient, userInfoEndpoint, "accessToken")
 	assert.Nil(t, fetchError)
 
 	var testUserInfoResponse UserInfoResponse
@@ -44,4 +51,30 @@ func TestFetchUserInfo(t *testing.T) {
 	assert.Nil(t, unmarshalErr)
 
 	assert.Equal(t, testUserInfoResponse, userInfoResponse)
+}
+
+// TestFetchUserInfoDeprecated tests that the deprecated function delegates to the new one
+func TestFetchUserInfoDeprecated(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	userInfoEndpoint := "http://example.com/oidc/jwks"
+	mockResponse := `{` +
+		`"sub": "sub",` +
+		`"name": "name",` +
+		`"username": "username"` +
+		`}`
+
+	httpmock.RegisterResponder(
+		"GET",
+		userInfoEndpoint,
+		httpmock.NewStringResponder(200, mockResponse),
+	)
+
+	// Test that deprecated function still works by calling the new implementation
+	userInfoResponse, fetchError := FetchUserInfo(userInfoEndpoint, "accessToken")
+	assert.Nil(t, fetchError)
+	assert.Equal(t, "sub", userInfoResponse.Sub)
+	assert.Equal(t, "name", userInfoResponse.Name)
+	assert.Equal(t, "username", userInfoResponse.Username)
 }


### PR DESCRIPTION
<!--
  For non-English users:
  It's okay to post in your language, but remember to use English for the body (you can paste the result of Google Translate), and put everything else as attachments.
  Issues with a non-English body will be DIRECTLY CLOSED until it's updated.
-->

<!-- MANDATORY -->
## Summary
<!-- Provide detailed PR description below -->
Add support for custom HTTP client injection to enable distributed tracing and observability. Uses functional options pattern for extensibility while maintaining full backward compatibility.

### Motivation

Users need to inject correlation IDs and trace IDs into HTTP requests for observability tools like Datadog, OTLP, and OpenTelemetry.

### Changes
- Added `LogtoClientOption` type and `WithHttpClient` function
- Modified `NewLogtoClient` to accept variadic options: `NewLogtoClient(config, storage, opts...)`
- Added comprehensive tests

### Usage Examples

#### Backward Compatible (no changes needed)

```go
  client := NewLogtoClient(config, storage)
```

#### Custom HTTP Client for Tracing

```go
  // Create tracing transport
  type TracingTransport struct {
      Base    http.RoundTripper
      TraceID string
  }

  func (t *TracingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
      req.Header.Set("X-Trace-ID", t.TraceID)
      return t.Base.RoundTrip(req)
  }

  // Use with Logto
  customClient := &http.Client{
      Transport: &TracingTransport{
          Base:    http.DefaultTransport,
          TraceID: "trace-abc123",
      },
  }

  client := NewLogtoClient(config, storage, WithHttpClient(customClient))
```

#### OpenTelemetry Integration

```go
  httpClient := &http.Client{
      Transport: otelhttp.NewTransport(http.DefaultTransport),
  }
  client := NewLogtoClient(config, storage, WithHttpClient(httpClient))
```

<!-- MANDATORY -->
## Testing
<!-- How did you test this PR? -->
UT & test locally.

<img width="786" height="528" alt="image" src="https://github.com/user-attachments/assets/66552f87-0262-4799-9a09-6240742a4a22" />


<!-- MANDATORY -->
## Checklist
<!-- The palest ink is better than the best memory -->

~~- [ ] `.changeset`~~
- [x] unit tests
~~- [ ] integration tests~~
- [x] necessary comments
