### PR TITLE
feat: add structured ResponseError for non-200 responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,29 @@ go get -u github.com/logto-io/go/v2/client
 | core   | Logto SDK core package               |
 | client | Logto client built upon the `core` package |
 
+## Error handling
+
+When the Logto server responds with a non-200 status code, SDK functions return a `*core.ResponseError` that carries the HTTP status code and the parsed OIDC error fields. Use `errors.As` to inspect it and turn server errors into user actions.
+
+For example, fetching user info with an expired or revoked refresh token fails with the OIDC error code `invalid_grant`, which means the user needs to sign in again:
+
+```go
+import (
+	"errors"
+
+	"github.com/logto-io/go/v2/core"
+)
+
+userInfo, err := logtoClient.FetchUserInfo()
+if err != nil {
+	var responseError *core.ResponseError
+	if errors.As(err, &responseError) && responseError.ErrorCode == "invalid_grant" {
+		// The refresh token is expired or revoked, redirect the user to sign in again.
+	}
+	// Handle other errors.
+}
+```
+
 ## Resources
 
 [![Website](https://img.shields.io/badge/website-logto.io-8262F8.svg)](https://logto.io/)

--- a/README.md
+++ b/README.md
@@ -49,24 +49,39 @@ go get -u github.com/logto-io/go/v2/client
 
 ## Error handling
 
-When the Logto server responds with a non-200 status code, SDK functions return a `*core.ResponseError` that carries the HTTP status code and the parsed OIDC error fields. Use `errors.As` to inspect it and turn server errors into user actions.
+SDK functions return structured errors that can be inspected with `errors.Is` and `errors.As` to turn failures into user actions.
 
-For example, fetching user info with an expired or revoked refresh token fails with the OIDC error code `invalid_grant`, which means the user needs to sign in again:
+The most common scenario: the stored refresh token has expired or been revoked, so the session cannot be renewed. `LogtoClient` methods (e.g. `GetAccessToken`, `FetchUserInfo`) report this as `client.ErrNotAuthenticated`, the same error returned when the user has never signed in:
 
 ```go
 import (
 	"errors"
 
-	"github.com/logto-io/go/v2/core"
+	"github.com/logto-io/go/v2/client"
 )
 
 userInfo, err := logtoClient.FetchUserInfo()
 if err != nil {
-	var responseError *core.ResponseError
-	if errors.As(err, &responseError) && responseError.ErrorCode == "invalid_grant" {
-		// The refresh token is expired or revoked, redirect the user to sign in again.
+	if errors.Is(err, client.ErrNotAuthenticated) {
+		// No valid session, redirect the user to sign in again.
 	}
 	// Handle other errors.
+}
+```
+
+For everything else, any non-200 response from the Logto server is a `*core.ResponseError` carrying the HTTP status code, the parsed OIDC and Logto error fields, and the raw body:
+
+```go
+import "github.com/logto-io/go/v2/core"
+
+var responseError *core.ResponseError
+if errors.As(err, &responseError) {
+	log.Printf(
+		"logto request failed: status=%d, code=%s, description=%s",
+		responseError.StatusCode,
+		responseError.Code,
+		responseError.ErrorDescription,
+	)
 }
 ```
 

--- a/client/client.go
+++ b/client/client.go
@@ -1,6 +1,8 @@
 package client
 
 import (
+	"errors"
+	"fmt"
 	"net/http"
 	"slices"
 	"time"
@@ -148,6 +150,12 @@ func (logtoClient *LogtoClient) GetAccessTokenWithOptions(options GetAccessToken
 	})
 
 	if refreshTokenErr != nil {
+		var responseError *core.ResponseError
+		// An invalid_grant error from the refresh token grant means the refresh
+		// token is no longer valid and the user has to sign in again.
+		if errors.As(refreshTokenErr, &responseError) && responseError.ErrorCode == invalidGrantErrorCode {
+			return AccessToken{}, fmt.Errorf("%w: %w", ErrNotAuthenticated, refreshTokenErr)
+		}
 		return AccessToken{}, refreshTokenErr
 	}
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -51,6 +51,83 @@ func TestGetAccessTokenShouldReturnNotAuthenticatedErrIfNoIdTokenAvailable(t *te
 	assert.Equal(t, ErrNotAuthenticated, getAccessTokenErr)
 }
 
+func TestGetAccessTokenShouldReturnNotAuthenticatedErrWhenRefreshTokenIsRejected(t *testing.T) {
+	var logtoClientSpy *LogtoClient
+	patchesForFetchOidcConfig := gomonkey.ApplyPrivateMethod(logtoClientSpy, "fetchOidcConfig", func(_ *LogtoClient) (core.OidcConfigResponse, error) {
+		return core.OidcConfigResponse{}, nil
+	})
+	defer patchesForFetchOidcConfig.Reset()
+
+	testResponseError := &core.ResponseError{
+		StatusCode: http.StatusBadRequest,
+		Code:       "oidc.invalid_grant",
+		Message:    "Grant request is invalid.",
+		ErrorCode:  "invalid_grant",
+	}
+
+	patchesForFetchTokenByRefreshToken := gomonkey.ApplyFunc(
+		core.FetchTokenByRefreshToken,
+		func(client *http.Client, options *core.FetchTokenByRefreshTokenOptions) (core.RefreshTokenResponse, error) {
+			return core.RefreshTokenResponse{}, testResponseError
+		},
+	)
+	defer patchesForFetchTokenByRefreshToken.Reset()
+
+	logtoClient := NewLogtoClient(
+		&LogtoConfig{},
+		&TestStorage{
+			data: map[string]string{
+				StorageKeyIdToken:      "id token",
+				StorageKeyRefreshToken: "expired refresh token",
+			},
+		},
+	)
+
+	_, getAccessTokenErr := logtoClient.GetAccessToken("")
+
+	assert.True(t, errors.Is(getAccessTokenErr, ErrNotAuthenticated))
+
+	var responseError *core.ResponseError
+	assert.True(t, errors.As(getAccessTokenErr, &responseError))
+	assert.Equal(t, testResponseError, responseError)
+}
+
+func TestGetAccessTokenShouldPropagateOtherResponseErrorsAsIs(t *testing.T) {
+	var logtoClientSpy *LogtoClient
+	patchesForFetchOidcConfig := gomonkey.ApplyPrivateMethod(logtoClientSpy, "fetchOidcConfig", func(_ *LogtoClient) (core.OidcConfigResponse, error) {
+		return core.OidcConfigResponse{}, nil
+	})
+	defer patchesForFetchOidcConfig.Reset()
+
+	testResponseError := &core.ResponseError{
+		StatusCode: http.StatusInternalServerError,
+		ErrorCode:  "server_error",
+	}
+
+	patchesForFetchTokenByRefreshToken := gomonkey.ApplyFunc(
+		core.FetchTokenByRefreshToken,
+		func(client *http.Client, options *core.FetchTokenByRefreshTokenOptions) (core.RefreshTokenResponse, error) {
+			return core.RefreshTokenResponse{}, testResponseError
+		},
+	)
+	defer patchesForFetchTokenByRefreshToken.Reset()
+
+	logtoClient := NewLogtoClient(
+		&LogtoConfig{},
+		&TestStorage{
+			data: map[string]string{
+				StorageKeyIdToken:      "id token",
+				StorageKeyRefreshToken: "refresh token",
+			},
+		},
+	)
+
+	_, getAccessTokenErr := logtoClient.GetAccessToken("")
+
+	assert.False(t, errors.Is(getAccessTokenErr, ErrNotAuthenticated))
+	assert.Equal(t, testResponseError, getAccessTokenErr)
+}
+
 func TestGetAccessTokenShouldReturnFetchedAccessTokenAndUpdateLocalAccessTokenIfLocalAccessTokenIsExpired(t *testing.T) {
 	testAccessToken := "refreshed access token"
 	testRefreshToken := "refresh token"

--- a/client/errors.go
+++ b/client/errors.go
@@ -2,7 +2,15 @@ package client
 
 import "errors"
 
+// invalidGrantErrorCode is the OIDC error code returned by the token endpoint
+// when the presented grant (e.g. the refresh token) is invalid (RFC 6749 5.2).
+const invalidGrantErrorCode = "invalid_grant"
+
 var (
+	// ErrNotAuthenticated is returned when no valid user session is available:
+	// the user has not signed in, no refresh token is stored, or the stored
+	// refresh token has been rejected by the server (expired or revoked).
+	// Use errors.Is to detect it and prompt the user to sign in again.
 	ErrNotAuthenticated            = errors.New("not authenticated")
 	ErrUnacknowledgedResourceFound = errors.New("unacknowledged resource found")
 	ErrMissingScopeOrganizations   = errors.New("missing 'urn:logto:scope:organizations' scope")

--- a/core/fetch_user_info_test.go
+++ b/core/fetch_user_info_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"testing"
 	"time"
@@ -51,6 +52,27 @@ func TestFetchUserInfoWithClient(t *testing.T) {
 	assert.Nil(t, unmarshalErr)
 
 	assert.Equal(t, testUserInfoResponse, userInfoResponse)
+}
+
+func TestFetchUserInfoWithClientShouldReturnResponseErrorOnErrorResponse(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	userInfoEndpoint := "http://example.com/oidc/me"
+	mockResponse := `{"code":"oidc.invalid_grant","message":"Grant request is invalid.","error":"invalid_grant","error_description":"grant request is invalid"}`
+
+	httpmock.RegisterResponder(
+		"GET",
+		userInfoEndpoint,
+		httpmock.NewStringResponder(400, mockResponse),
+	)
+
+	_, fetchError := FetchUserInfoWithClient(&http.Client{}, userInfoEndpoint, "expiredAccessToken")
+
+	var responseError *ResponseError
+	assert.True(t, errors.As(fetchError, &responseError))
+	assert.Equal(t, http.StatusBadRequest, responseError.StatusCode)
+	assert.Equal(t, "invalid_grant", responseError.ErrorCode)
 }
 
 // TestFetchUserInfoDeprecated tests that the deprecated function delegates to the new one

--- a/core/parse_response.go
+++ b/core/parse_response.go
@@ -2,7 +2,6 @@ package core
 
 import (
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 )
@@ -15,7 +14,13 @@ func parseDataFromResponse(response *http.Response, dest interface{}) error {
 	}
 
 	if response.StatusCode != http.StatusOK {
-		return fmt.Errorf("unexpected status code: %d, response body: %s", response.StatusCode, body)
+		responseError := &ResponseError{
+			StatusCode: response.StatusCode,
+			RawBody:    string(body),
+		}
+		// The error fields stay empty when the body is not a JSON object.
+		_ = json.Unmarshal(body, responseError)
+		return responseError
 	}
 
 	return json.Unmarshal(body, &dest)

--- a/core/parse_response_test.go
+++ b/core/parse_response_test.go
@@ -1,0 +1,65 @@
+package core
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func buildTestResponse(statusCode int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: statusCode,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+func TestParseDataFromResponseShouldParseDataOnOkResponse(t *testing.T) {
+	var dest struct {
+		Foo string `json:"foo"`
+	}
+
+	err := parseDataFromResponse(buildTestResponse(http.StatusOK, `{"foo":"bar"}`), &dest)
+
+	assert.Nil(t, err)
+	assert.Equal(t, "bar", dest.Foo)
+}
+
+func TestParseDataFromResponseShouldReturnResponseErrorWithParsedErrorBody(t *testing.T) {
+	mockResponseBody := `{"code":"oidc.invalid_grant","message":"Grant request is invalid.","error":"invalid_grant","error_description":"grant request is invalid","error_uri":"https://openid.sh/debug/invalid_grant"}`
+
+	var dest interface{}
+	err := parseDataFromResponse(buildTestResponse(http.StatusBadRequest, mockResponseBody), &dest)
+
+	var responseError *ResponseError
+	assert.True(t, errors.As(err, &responseError))
+	assert.Equal(t, http.StatusBadRequest, responseError.StatusCode)
+	assert.Equal(t, "oidc.invalid_grant", responseError.Code)
+	assert.Equal(t, "Grant request is invalid.", responseError.Message)
+	assert.Equal(t, "invalid_grant", responseError.ErrorCode)
+	assert.Equal(t, "grant request is invalid", responseError.ErrorDescription)
+	assert.Equal(t, "https://openid.sh/debug/invalid_grant", responseError.ErrorUri)
+	assert.Equal(t, mockResponseBody, responseError.RawBody)
+	assert.Equal(t, "unexpected status code: 400, response body: "+mockResponseBody, err.Error())
+}
+
+func TestParseDataFromResponseShouldReturnResponseErrorOnNonJsonBody(t *testing.T) {
+	mockResponseBody := "Bad Gateway"
+
+	var dest interface{}
+	err := parseDataFromResponse(buildTestResponse(http.StatusBadGateway, mockResponseBody), &dest)
+
+	var responseError *ResponseError
+	assert.True(t, errors.As(err, &responseError))
+	assert.Equal(t, http.StatusBadGateway, responseError.StatusCode)
+	assert.Empty(t, responseError.Code)
+	assert.Empty(t, responseError.Message)
+	assert.Empty(t, responseError.ErrorCode)
+	assert.Empty(t, responseError.ErrorDescription)
+	assert.Empty(t, responseError.ErrorUri)
+	assert.Equal(t, mockResponseBody, responseError.RawBody)
+	assert.Equal(t, "unexpected status code: 502, response body: "+mockResponseBody, err.Error())
+}

--- a/core/response_error.go
+++ b/core/response_error.go
@@ -8,13 +8,16 @@ import "fmt"
 // are parsed into the corresponding struct fields. Otherwise only StatusCode
 // and RawBody are populated.
 //
-// Use errors.As to inspect the error details, e.g. to detect an invalid
-// (expired or revoked) refresh token and prompt the user to sign in again:
+// Use errors.As to inspect the details of a failed request:
 //
 //	var responseError *core.ResponseError
-//	if errors.As(err, &responseError) && responseError.ErrorCode == "invalid_grant" {
-//		// Redirect the user to sign in again.
+//	if errors.As(err, &responseError) {
+//		log.Printf("status: %d, code: %s", responseError.StatusCode, responseError.Code)
 //	}
+//
+// When using LogtoClient, prefer the sentinel errors in the client package for
+// well-known scenarios: e.g. a rejected refresh token is reported as
+// ErrNotAuthenticated.
 type ResponseError struct {
 	// StatusCode is the HTTP status code of the response.
 	StatusCode int `json:"-"`

--- a/core/response_error.go
+++ b/core/response_error.go
@@ -1,0 +1,37 @@
+package core
+
+import "fmt"
+
+// ResponseError represents a non-200 response returned by the Logto server.
+//
+// When the response body is a JSON object, the OIDC and Logto error fields
+// are parsed into the corresponding struct fields. Otherwise only StatusCode
+// and RawBody are populated.
+//
+// Use errors.As to inspect the error details, e.g. to detect an invalid
+// (expired or revoked) refresh token and prompt the user to sign in again:
+//
+//	var responseError *core.ResponseError
+//	if errors.As(err, &responseError) && responseError.ErrorCode == "invalid_grant" {
+//		// Redirect the user to sign in again.
+//	}
+type ResponseError struct {
+	// StatusCode is the HTTP status code of the response.
+	StatusCode int `json:"-"`
+	// Code is the Logto error code, e.g. "oidc.invalid_grant".
+	Code string `json:"code"`
+	// Message is the human-readable message of the Logto error.
+	Message string `json:"message"`
+	// ErrorCode is the OIDC error code, e.g. "invalid_grant".
+	ErrorCode string `json:"error"`
+	// ErrorDescription is the human-readable description of the OIDC error.
+	ErrorDescription string `json:"error_description"`
+	// ErrorUri is a URI to a web page with more information about the error.
+	ErrorUri string `json:"error_uri"`
+	// RawBody is the raw response body.
+	RawBody string `json:"-"`
+}
+
+func (responseError *ResponseError) Error() string {
+	return fmt.Sprintf("unexpected status code: %d, response body: %s", responseError.StatusCode, responseError.RawBody)
+}

--- a/gin-sample/main.go
+++ b/gin-sample/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"net/http"
 	"os"
 	"strings"
@@ -9,6 +10,7 @@ import (
 	"github.com/gin-contrib/sessions/memstore"
 	"github.com/gin-gonic/gin"
 	"github.com/logto-io/go/v2/client"
+	"github.com/logto-io/go/v2/core"
 )
 
 var (
@@ -136,7 +138,27 @@ func main() {
 			userInfoResponse, fetchUserInfoErr := logtoClient.FetchUserInfo()
 
 			if fetchUserInfoErr != nil {
-				ctx.String(http.StatusOK, fetchUserInfoErr.Error())
+				// The stored refresh token is expired or revoked, so the
+				// session cannot be renewed. Ask the user to sign in again.
+				if errors.Is(fetchUserInfoErr, client.ErrNotAuthenticated) {
+					ctx.Redirect(http.StatusTemporaryRedirect, "/sign-in")
+					return
+				}
+
+				// For other server errors, the details are available on
+				// *core.ResponseError.
+				var responseError *core.ResponseError
+				if errors.As(fetchUserInfoErr, &responseError) {
+					ctx.String(
+						http.StatusBadGateway,
+						"Failed to fetch user info: status=%d, code=%s",
+						responseError.StatusCode,
+						responseError.Code,
+					)
+					return
+				}
+
+				ctx.String(http.StatusInternalServerError, fetchUserInfoErr.Error())
 				return
 			}
 


### PR DESCRIPTION
## Summary

Make server errors handleable so that SDK consumers can turn failures into user actions. The design has two layers: the `core` package carries raw error facts, and the `client` package maps well-known scenarios to sentinel errors.

Core layer:

- `parseDataFromResponse` now returns `*core.ResponseError` for non-200 responses, carrying `StatusCode`, the parsed OIDC and Logto error fields (`Code`, `Message`, `ErrorCode`, `ErrorDescription`, `ErrorUri`), and the raw response body
- Non-JSON error bodies also return `*ResponseError`, with only `StatusCode` and `RawBody` populated
- The `Error()` message keeps the previous format, so existing logs stay unchanged

Client layer:

- When the refresh token grant fails with the OIDC `invalid_grant` error (refresh token expired, revoked, or not issued to this client), the token refreshing flow now wraps the error with `ErrNotAuthenticated`, so one `errors.Is` check covers both "never signed in" and "session expired"
- The wrapping is scoped to the refresh flow only. An `invalid_grant` during the sign-in callback code exchange propagates as a plain `*ResponseError`, since it usually indicates a misconfiguration and blindly redirecting to sign-in again could loop
- Network errors and 5xx responses are not treated as unauthenticated either, they propagate as is so a temporary server outage does not sign everyone out
- The original `*ResponseError` stays inspectable through `errors.As` on the wrapped error

### Usage

```go
userInfo, err := logtoClient.FetchUserInfo()
if err != nil {
    if errors.Is(err, client.ErrNotAuthenticated) {
        // No valid session, redirect the user to sign in again.
    }

    // For other server errors, the details are available on *core.ResponseError.
    var responseError *core.ResponseError
    if errors.As(err, &responseError) {
        log.Printf("status=%d, code=%s", responseError.StatusCode, responseError.Code)
    }
}
```

Docs and sample:

- Added an error handling section to the README covering both layers
- Updated the `/user-info` route in gin-sample to demonstrate the full pattern: redirect to `/sign-in` on `ErrNotAuthenticated`, and report the status code and error code from `*core.ResponseError` for other server errors

### Breaking changes

None, additive and behavior-compatible:

- No existing exported API is changed or removed, `apidiff` against `v2` reports only `ResponseError: added` in `core` and no changes in `client`
- The error text of `*ResponseError` keeps the exact previous format (asserted in tests)
- The previous concrete error type came from `fmt.Errorf` and was not referenceable by consumers, so no `errors.Is`/`errors.As`/type assertion could have depended on it
- One behavioral note: for the rejected refresh token case, the error message now gets a "not authenticated: " prefix from the wrapping. Only exact-string matching on that undocumented message could notice, `strings.Contains` style checks still match

Safe to ship as a minor release.

Closes #174

## Testing

unit tests

## Checklist

~~- [ ] `.changeset`~~
- [x] unit tests
~~- [ ] integration tests~~
- [x] necessary comments
