### PR TITLE
feat: add BaseUrl config for apps behind reverse proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,26 @@ if errors.As(err, &responseError) {
 }
 ```
 
+## Running behind a reverse proxy
+
+By default, `HandleSignInCallback` reconstructs the callback URI from the incoming request, inferring the scheme from the TLS state (or the `X-Forwarded-Proto` header) and the host from the `Host` header.
+
+If your application runs behind reverse proxies or multi-layer gateways (e.g., Cloudflare -> ALB -> Nginx, or Firebase Hosting -> Cloud Run), the scheme and host seen by your application may differ from the public address, causing sign-in callbacks to fail with a "callback uri not match redirect uri" error. Trusting these headers also exposes the application to Host header injection.
+
+To avoid this, set the optional `BaseUrl` in `LogtoConfig` to the public base URL of your application. It must be an absolute URL with a scheme and may include a path prefix:
+
+```go
+logtoConfig := &client.LogtoConfig{
+	Endpoint:  "<your-logto-endpoint>",
+	AppId:     "<your-application-id>",
+	AppSecret: "<your-application-secret>",
+	// The public base URL of your application
+	BaseUrl:   "https://my-app.com",
+}
+```
+
+When `BaseUrl` is set, the callback URI is constructed by directly appending the incoming request URI (path and query) to it, and the request's `Host` and `X-Forwarded-Proto` headers are no longer used. Make sure the concatenated result matches the public callback URL registered as the redirect URI — for example, if a proxy strips a path prefix before forwarding requests to your application, include that prefix in `BaseUrl`.
+
 ## Resources
 
 [![Website](https://img.shields.io/badge/website-logto.io-8262F8.svg)](https://logto.io/)

--- a/client/handle_sign_in_callback.go
+++ b/client/handle_sign_in_callback.go
@@ -16,7 +16,15 @@ func (logtoClient *LogtoClient) HandleSignInCallback(request *http.Request) erro
 		return parseSignInSessionErr
 	}
 
-	callbackUri := GetOriginRequestUrl(request)
+	// The scheme and host inferred from the incoming request may not match the
+	// public address when the application runs behind reverse proxies, so prefer
+	// the configured BaseUrl to construct the callback URI.
+	var callbackUri string
+	if logtoClient.logtoConfig.BaseUrl != "" {
+		callbackUri = logtoClient.logtoConfig.BaseUrl + request.RequestURI
+	} else {
+		callbackUri = GetOriginRequestUrl(request)
+	}
 	code, retrieveCodeErr := core.VerifyAndParseCodeFromCallbackUri(callbackUri, signInSession.RedirectUri, signInSession.State)
 	if retrieveCodeErr != nil {
 		return retrieveCodeErr

--- a/client/handle_sign_in_callback_test.go
+++ b/client/handle_sign_in_callback_test.go
@@ -81,3 +81,99 @@ func TestHandleSignInCallbackShouldHandleCallbackCorrectly(t *testing.T) {
 	assert.Nil(t, getAccessTokenErr)
 	assert.Equal(t, testAccessToken, accessToken.Token)
 }
+
+func TestHandleSignInCallbackShouldUseBaseUrlToConstructCallbackUriWhenBaseUrlIsProvided(t *testing.T) {
+	testCode := "testCode"
+	testState := "testState"
+
+	testCodeTokenResponse := core.CodeTokenResponse{
+		AccessToken:  "access token",
+		RefreshToken: "refresh token",
+		IdToken:      "id token",
+		Scope:        "openid",
+		ExpireIn:     3600,
+	}
+
+	codeUsedToFetchToken := ""
+	patchesForFetchTokenByAuthorizationCode := gomonkey.ApplyFunc(
+		core.FetchTokenByAuthorizationCode,
+		func(client *http.Client, options *core.FetchTokenByAuthorizationCodeOptions) (core.CodeTokenResponse, error) {
+			codeUsedToFetchToken = options.Code
+			return testCodeTokenResponse, nil
+		},
+	)
+	defer patchesForFetchTokenByAuthorizationCode.Reset()
+
+	patchesForVerifyIdToken := gomonkey.ApplyFunc(
+		core.VerifyIdToken,
+		func(idToken, clientId, issuer string, jwks *jose.JSONWebKeySet) error {
+			return nil
+		},
+	)
+	defer patchesForVerifyIdToken.Reset()
+
+	var logtoClientSpy *LogtoClient
+	patchesForFetchOidcConfig := gomonkey.ApplyPrivateMethod(logtoClientSpy, "fetchOidcConfig", func(_ *LogtoClient) (core.OidcConfigResponse, error) {
+		return core.OidcConfigResponse{}, nil
+	})
+	defer patchesForFetchOidcConfig.Reset()
+
+	patchesForCreateRemoteJwks := gomonkey.ApplyPrivateMethod(logtoClientSpy, "createRemoteJwks", func(_ *LogtoClient) (*jose.JSONWebKeySet, error) {
+		return &jose.JSONWebKeySet{}, nil
+	})
+	defer patchesForCreateRemoteJwks.Reset()
+
+	storage := &TestStorage{
+		data: map[string]string{
+			StorageKeySignInSession: `{"RedirectUri":"https://my-app.com/sign-in-callback","CodeVerifier":"codeVerifier","CodeChallenge":"codeChallenge","State":"` + testState + `"}`,
+		},
+	}
+
+	logtoClient := NewLogtoClient(&LogtoConfig{BaseUrl: "https://my-app.com"}, storage)
+
+	// Simulate the request received behind reverse proxies: plain HTTP with an internal host.
+	signInCallbackRequest, createSignInCallbackRequestErr := http.NewRequest(
+		"GET",
+		"http://internal-host:8080/sign-in-callback?code="+testCode+"&state="+testState,
+		nil,
+	)
+	assert.Nil(t, createSignInCallbackRequestErr)
+	// specify request uri before really perform a request
+	signInCallbackRequest.RequestURI = "/sign-in-callback?code=" + testCode + "&state=" + testState
+
+	handleSignInErr := logtoClient.HandleSignInCallback(signInCallbackRequest)
+	assert.Nil(t, handleSignInErr)
+
+	assert.Equal(t, testCode, codeUsedToFetchToken)
+	assert.True(t, logtoClient.IsAuthenticated())
+}
+
+func TestHandleSignInCallbackShouldInferCallbackUriFromRequestWhenBaseUrlIsNotProvided(t *testing.T) {
+	callbackUriUsedForVerification := ""
+	patchesForVerifyAndParseCodeFromCallbackUri := gomonkey.ApplyFunc(
+		core.VerifyAndParseCodeFromCallbackUri,
+		func(callbackUri, redirectUri, state string) (string, error) {
+			callbackUriUsedForVerification = callbackUri
+			return "", core.ErrCallbackUriNotMatchRedirectUri
+		},
+	)
+	defer patchesForVerifyAndParseCodeFromCallbackUri.Reset()
+
+	storage := &TestStorage{
+		data: map[string]string{
+			StorageKeySignInSession: `{"RedirectUri":"https://my-app.com/sign-in-callback","CodeVerifier":"codeVerifier","CodeChallenge":"codeChallenge","State":"state"}`,
+		},
+	}
+
+	logtoClient := NewLogtoClient(&LogtoConfig{}, storage)
+
+	signInCallbackRequest, createSignInCallbackRequestErr := http.NewRequest("GET", "http://internal-host:8080/sign-in-callback", nil)
+	assert.Nil(t, createSignInCallbackRequestErr)
+	// specify request uri before really perform a request
+	signInCallbackRequest.RequestURI = "/sign-in-callback"
+
+	handleSignInErr := logtoClient.HandleSignInCallback(signInCallbackRequest)
+	assert.Equal(t, core.ErrCallbackUriNotMatchRedirectUri, handleSignInErr)
+
+	assert.Equal(t, "http://internal-host:8080/sign-in-callback", callbackUriUsedForVerification)
+}

--- a/client/logto_config.go
+++ b/client/logto_config.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"slices"
+	"strings"
 
 	"github.com/logto-io/go/v2/core"
 )
@@ -14,6 +15,17 @@ type LogtoConfig struct {
 	Resources             []string
 	Prompt                string
 	IncludeReservedScopes *bool
+	// BaseUrl is the public base URL of your application, e.g. "https://my-app.com".
+	// It must be an absolute URL with a scheme and may include a path prefix.
+	//
+	// When set, `HandleSignInCallback` constructs the callback URI from BaseUrl and
+	// the incoming request path, instead of inferring the scheme and host from the
+	// request (`Host` and `X-Forwarded-Proto` headers). Set it when your application
+	// runs behind reverse proxies or multi-layer gateways, where the inferred values
+	// may not match the public address and the headers cannot be trusted.
+	//
+	// When empty, the callback URI is inferred from the incoming request as before.
+	BaseUrl string
 }
 
 /**
@@ -21,8 +33,11 @@ type LogtoConfig struct {
  *
  * - Add default scopes (`openid`, `offline_access` and `profile`) if not provided.
  * - Add `ReservedResource.Organization` to resources if `UserScope.Organizations` is included in scopes.
+ * - Trim the trailing slash of `BaseUrl` so it can be safely concatenated with a request path.
  */
 func (logtoConfig *LogtoConfig) normalized() {
+	logtoConfig.BaseUrl = strings.TrimSuffix(logtoConfig.BaseUrl, "/")
+
 	includeReservedScopes := logtoConfig.IncludeReservedScopes
 	if includeReservedScopes == nil || *includeReservedScopes {
 		for _, defaultScope := range core.DefaultScopes {

--- a/client/logto_config_test.go
+++ b/client/logto_config_test.go
@@ -1,0 +1,15 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizedShouldTrimTrailingSlashOfBaseUrl(t *testing.T) {
+	logtoConfig := LogtoConfig{BaseUrl: "https://my-app.com/"}
+
+	logtoConfig.normalized()
+
+	assert.Equal(t, "https://my-app.com", logtoConfig.BaseUrl)
+}


### PR DESCRIPTION
## Summary

Add an optional `BaseUrl` field to `LogtoConfig` so applications behind reverse proxies can pass the sign-in callback verification.

- Behind multi-layer gateways (e.g. Firebase Hosting -> Cloud Run, Cloudflare -> ALB -> Nginx), the scheme and host inferred from the incoming request differ from the public address, so `HandleSignInCallback` fails with `callback uri not match redirect uri`; trusting the `Host` header also risks Host header injection
- When `BaseUrl` is set, the callback URI is constructed as `BaseUrl` (trailing slash trimmed) + the incoming request URI, skipping request inspection entirely
- When it is empty, the behavior is unchanged (fully backward compatible)
- Document the new option in a "Running behind a reverse proxy" README section

close #185
close #177

## Testing

unit tests

## Checklist

~~- [ ] `.changeset`~~
- [x] unit tests
~~- [ ] integration tests~~
- [x] necessary comments
