### PR TITLE
feat: support standard profile claims and raw claim access

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,32 @@ go get -u github.com/logto-io/go/v2/client
 | core   | Logto SDK core package               |
 | client | Logto client built upon the `core` package |
 
+## User info and ID token claims
+
+`client.FetchUserInfo` and `client.GetIdTokenClaims` return `core.UserInfoResponse` and `core.IdTokenClaims` respectively. Besides basic claims such as `sub`, `name`, `email`, both types model the [standard claims](https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims) included in the `profile` scope: `family_name`, `given_name`, `middle_name`, `nickname`, `preferred_username`, `profile`, `website`, `gender`, `birthdate`, `zoneinfo`, `locale`, as well as `created_at` and `updated_at`. Logto only returns these standard claims when their values are not empty, so absent claims are left as zero values.
+
+To access claims that are not modeled as struct fields, e.g. custom claims, use the `GetClaim` method:
+
+```go
+userInfo, err := logtoClient.FetchUserInfo()
+if err != nil {
+	// Handle error
+}
+
+if value, ok := userInfo.GetClaim("custom_claim"); ok {
+	// Use the claim value
+}
+
+idTokenClaims, err := logtoClient.GetIdTokenClaims()
+if err != nil {
+	// Handle error
+}
+
+if value, ok := idTokenClaims.GetClaim("custom_claim"); ok {
+	// Use the claim value
+}
+```
+
 ## Error handling
 
 SDK functions return structured errors that can be inspected with `errors.Is` and `errors.As` to turn failures into user actions.

--- a/core/decode_id_token_test.go
+++ b/core/decode_id_token_test.go
@@ -27,7 +27,49 @@ func TestDecodeIdTokenShouldGetExpectedIdTokenClaims(t *testing.T) {
 	idTokenClaims, decodeIdTokenErr := DecodeIdToken(idToken)
 	assert.Nil(t, decodeIdTokenErr)
 
+	// Decoding populates the raw claims, clear them to compare the modeled
+	// fields against the literal expectation.
+	assert.NotNil(t, idTokenClaims.rawClaims)
+	idTokenClaims.rawClaims = nil
 	assert.Equal(t, idTokenClaims, testClaims)
+}
+
+func TestDecodeIdTokenShouldSupportGettingAnyClaimFromRawClaims(t *testing.T) {
+	now := time.Now()
+	testClaims := map[string]any{
+		"iss":          "1234567890",
+		"sub":          "1234567890",
+		"aud":          "1234567890",
+		"exp":          now.Add(time.Hour).Unix(),
+		"iat":          now.Unix(),
+		"family_name":  "Doe",
+		"given_name":   "John",
+		"custom_claim": "custom_value",
+	}
+
+	idToken, _, generateError := generateRsaSigningTestTokenAndCorrespondJwks(testClaims)
+	assert.Nil(t, generateError)
+
+	idTokenClaims, decodeIdTokenErr := DecodeIdToken(idToken)
+	assert.Nil(t, decodeIdTokenErr)
+
+	// Standard profile claims are populated as modeled fields.
+	assert.Equal(t, "Doe", idTokenClaims.FamilyName)
+	assert.Equal(t, "John", idTokenClaims.GivenName)
+
+	// Claims that are not modeled as struct fields are accessible via GetClaim.
+	customClaim, ok := idTokenClaims.GetClaim("custom_claim")
+	assert.True(t, ok)
+	assert.Equal(t, "custom_value", customClaim)
+
+	// Modeled claims are accessible via GetClaim as well.
+	familyName, ok := idTokenClaims.GetClaim("family_name")
+	assert.True(t, ok)
+	assert.Equal(t, "Doe", familyName)
+
+	// Absent claims are reported as not present.
+	_, ok = idTokenClaims.GetClaim("nonexistent_claim")
+	assert.False(t, ok)
 }
 
 func TestDecodeIdTokenShouldReturnErrorWhenTokenIsInvalid(t *testing.T) {

--- a/core/fetch_user_info_test.go
+++ b/core/fetch_user_info_test.go
@@ -25,6 +25,11 @@ func TestFetchUserInfoWithClient(t *testing.T) {
 		`"email_verified": true,` +
 		`"phone_number": "12345678",` +
 		`"phone_number_verified": true,` +
+		`"family_name": "Doe",` +
+		`"given_name": "John",` +
+		`"created_at": 1700000000000,` +
+		`"updated_at": 1700000001000,` +
+		`"custom_claim": "custom_value",` +
 		`"custom_data": {"level": 1},` +
 		`"identities": {"google": {"id": 1}},` +
 		`"roles": ["role1", "role2"],` +
@@ -52,6 +57,16 @@ func TestFetchUserInfoWithClient(t *testing.T) {
 	assert.Nil(t, unmarshalErr)
 
 	assert.Equal(t, testUserInfoResponse, userInfoResponse)
+
+	assert.Equal(t, "Doe", userInfoResponse.FamilyName)
+	assert.Equal(t, "John", userInfoResponse.GivenName)
+	assert.Equal(t, int64(1700000000000), userInfoResponse.CreatedAt)
+	assert.Equal(t, int64(1700000001000), userInfoResponse.UpdatedAt)
+
+	// Claims that are not modeled as struct fields are accessible via GetClaim.
+	customClaim, ok := userInfoResponse.GetClaim("custom_claim")
+	assert.True(t, ok)
+	assert.Equal(t, "custom_value", customClaim)
 }
 
 func TestFetchUserInfoWithClientShouldReturnResponseErrorOnErrorResponse(t *testing.T) {

--- a/core/test_utils.go
+++ b/core/test_utils.go
@@ -10,7 +10,7 @@ import (
 	"github.com/go-jose/go-jose/v4/jwt"
 )
 
-func generateTestTokenBySigningKey(keyId string, signingKey jose.SigningKey, idTokenClaims IdTokenClaims) (string, error) {
+func generateTestTokenBySigningKey(keyId string, signingKey jose.SigningKey, claims any) (string, error) {
 	signingKeyOptions := jose.SignerOptions{}
 	signingKeyOptions.WithType("JWT")
 	signingKeyOptions.WithHeader("kid", keyId)
@@ -22,7 +22,7 @@ func generateTestTokenBySigningKey(keyId string, signingKey jose.SigningKey, idT
 
 	builder := jwt.Signed(rsaSigner)
 
-	token, buildTokenError := builder.Claims(idTokenClaims).Serialize()
+	token, buildTokenError := builder.Claims(claims).Serialize()
 
 	if buildTokenError != nil {
 		return "", buildTokenError
@@ -75,7 +75,7 @@ func generateEcdsaSigningKeyAndJwks(signingKeyId string) (jose.SigningKey, jose.
 }
 
 func generateTestTokenAndCorrespondJwks(
-	idTokenClaims IdTokenClaims,
+	claims any,
 	signingKeyAndJwksGenerator func(string) (jose.SigningKey, jose.JSONWebKeySet, error),
 ) (string, jose.JSONWebKeySet, error) {
 	signingKeyId := "test-signing-key-id"
@@ -84,7 +84,7 @@ func generateTestTokenAndCorrespondJwks(
 		return "", jose.JSONWebKeySet{}, generateKeyError
 	}
 
-	token, generateTokenError := generateTestTokenBySigningKey(signingKeyId, signingKey, idTokenClaims)
+	token, generateTokenError := generateTestTokenBySigningKey(signingKeyId, signingKey, claims)
 	if generateTokenError != nil {
 		return "", jose.JSONWebKeySet{}, generateTokenError
 	}
@@ -92,10 +92,10 @@ func generateTestTokenAndCorrespondJwks(
 	return token, jwks, nil
 }
 
-func generateRsaSigningTestTokenAndCorrespondJwks(idTokenClaims IdTokenClaims) (string, jose.JSONWebKeySet, error) {
-	return generateTestTokenAndCorrespondJwks(idTokenClaims, generateRsaSigningKeyAndJwks)
+func generateRsaSigningTestTokenAndCorrespondJwks(claims any) (string, jose.JSONWebKeySet, error) {
+	return generateTestTokenAndCorrespondJwks(claims, generateRsaSigningKeyAndJwks)
 }
 
-func generateEcdsaSigningTestTokenAndCorrespondJwks(idTokenClaims IdTokenClaims) (string, jose.JSONWebKeySet, error) {
-	return generateTestTokenAndCorrespondJwks(idTokenClaims, generateEcdsaSigningKeyAndJwks)
+func generateEcdsaSigningTestTokenAndCorrespondJwks(claims any) (string, jose.JSONWebKeySet, error) {
+	return generateTestTokenAndCorrespondJwks(claims, generateEcdsaSigningKeyAndJwks)
 }

--- a/core/type.go
+++ b/core/type.go
@@ -1,5 +1,7 @@
 package core
 
+import "encoding/json"
+
 type OidcConfigResponse struct {
 	AuthorizationEndpoint string `json:"authorization_endpoint"`
 	TokenEndpoint         string `json:"token_endpoint"`
@@ -27,18 +29,34 @@ type Organization struct {
 }
 
 type UserInfoResponse struct {
-	Sub                 string                 `json:"sub"`                   // The user's unique ID.
-	Name                string                 `json:"name"`                  // The user's full name.
-	Username            string                 `json:"username"`              // The user's username.
-	Picture             string                 `json:"picture"`               // The user's profile picture URL.
-	Email               string                 `json:"email"`                 // The user's email address.
-	EmailVerified       bool                   `json:"email_verified"`        // Whether the user's email address is verified.
-	PhoneNumber         string                 `json:"phone_number"`          // The user's phone number.
-	PhoneNumberVerified bool                   `json:"phone_number_verified"` // Whether the user's phone number is verified.
-	CustomData          map[string]interface{} `json:"custom_data"`           // The user's custom data
-	Identities          map[string]interface{} `json:"identities"`            // The user's social identities information
-	Roles               []string               `json:"roles"`                 // The role names of the current user.
-	Organizations       []string               `json:"organizations"`         // The organization IDs that the user has membership.
+	Sub                 string `json:"sub"`                   // The user's unique ID.
+	Name                string `json:"name"`                  // The user's full name.
+	Username            string `json:"username"`              // The user's username.
+	Picture             string `json:"picture"`               // The user's profile picture URL.
+	Email               string `json:"email"`                 // The user's email address.
+	EmailVerified       bool   `json:"email_verified"`        // Whether the user's email address is verified.
+	PhoneNumber         string `json:"phone_number"`          // The user's phone number.
+	PhoneNumberVerified bool   `json:"phone_number_verified"` // Whether the user's phone number is verified.
+	CreatedAt           int64  `json:"created_at"`            // Time when the user was created, in milliseconds since the Unix epoch.
+	UpdatedAt           int64  `json:"updated_at"`            // Time when the user was last updated, in milliseconds since the Unix epoch.
+	// The following claims are standard OIDC claims included in the `profile` scope.
+	// Logto only returns them when their values are not empty, so absent claims are
+	// left as zero values.
+	FamilyName        string                 `json:"family_name"`        // The user's family name.
+	GivenName         string                 `json:"given_name"`         // The user's given name.
+	MiddleName        string                 `json:"middle_name"`        // The user's middle name.
+	Nickname          string                 `json:"nickname"`           // The user's nickname.
+	PreferredUsername string                 `json:"preferred_username"` // The username by which the user wishes to be referred to.
+	Profile           string                 `json:"profile"`            // The URL of the user's profile page.
+	Website           string                 `json:"website"`            // The URL of the user's website.
+	Gender            string                 `json:"gender"`             // The user's gender.
+	Birthdate         string                 `json:"birthdate"`          // The user's birthdate.
+	Zoneinfo          string                 `json:"zoneinfo"`           // The user's time zone, e.g. `Europe/Paris`.
+	Locale            string                 `json:"locale"`             // The user's locale, e.g. `en-US`.
+	CustomData        map[string]interface{} `json:"custom_data"`        // The user's custom data
+	Identities        map[string]interface{} `json:"identities"`         // The user's social identities information
+	Roles             []string               `json:"roles"`              // The role names of the current user.
+	Organizations     []string               `json:"organizations"`      // The organization IDs that the user has membership.
 	// The organization roles that the user has.
 	// Each role is in the format of `<organization_id>:<role_name>`.
 	// # Example #
@@ -48,25 +66,113 @@ type UserInfoResponse struct {
 	// ```
 	OrganizationRoles []string       `json:"organization_roles"`
 	OrganizationData  []Organization `json:"organization_data"` // The organization data that the user has membership.
+
+	// rawClaims holds all claims decoded from the raw JSON payload, including
+	// claims that are not modeled as struct fields. Use GetClaim to access them.
+	rawClaims map[string]any
+}
+
+// userInfoResponseAlias is an alias of UserInfoResponse used to avoid infinite
+// recursion when unmarshaling.
+type userInfoResponseAlias UserInfoResponse
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+// In addition to populating the modeled fields, it keeps all claims in the raw
+// JSON payload so that unmodeled claims can be accessed via GetClaim.
+func (userInfoResponse *UserInfoResponse) UnmarshalJSON(data []byte) error {
+	var alias userInfoResponseAlias
+	if err := json.Unmarshal(data, &alias); err != nil {
+		return err
+	}
+
+	var rawClaims map[string]any
+	if err := json.Unmarshal(data, &rawClaims); err != nil {
+		return err
+	}
+
+	*userInfoResponse = UserInfoResponse(alias)
+	userInfoResponse.rawClaims = rawClaims
+
+	return nil
+}
+
+// GetClaim returns the raw value of the given claim in the userinfo response,
+// including claims that are not modeled as struct fields, e.g. custom claims.
+// The second return value indicates whether the claim is present.
+func (userInfoResponse UserInfoResponse) GetClaim(name string) (any, bool) {
+	value, ok := userInfoResponse.rawClaims[name]
+	return value, ok
 }
 
 type IdTokenClaims struct {
-	Iss                 string   `json:"iss"`
-	Sub                 string   `json:"sub"`
-	Aud                 string   `json:"aud"`
-	Exp                 int64    `json:"exp"`
-	Iat                 int64    `json:"iat"`
-	AtHash              string   `json:"at_hash"`
-	Name                string   `json:"name"`
-	Username            string   `json:"username"`
-	Picture             string   `json:"picture"`
-	Email               string   `json:"email"`
-	EmailVerified       bool     `json:"email_verified"`
-	PhoneNumber         string   `json:"phone_number"`
-	PhoneNumberVerified bool     `json:"phone_number_verified"`
-	Roles               []string `json:"roles"`
-	Organizations       []string `json:"organizations"`
-	OrganizationRoles   []string `json:"organization_roles"`
+	Iss                 string `json:"iss"`
+	Sub                 string `json:"sub"`
+	Aud                 string `json:"aud"`
+	Exp                 int64  `json:"exp"`
+	Iat                 int64  `json:"iat"`
+	AtHash              string `json:"at_hash"`
+	Name                string `json:"name"`
+	Username            string `json:"username"`
+	Picture             string `json:"picture"`
+	Email               string `json:"email"`
+	EmailVerified       bool   `json:"email_verified"`
+	PhoneNumber         string `json:"phone_number"`
+	PhoneNumberVerified bool   `json:"phone_number_verified"`
+	CreatedAt           int64  `json:"created_at"` // Time when the user was created, in milliseconds since the Unix epoch.
+	UpdatedAt           int64  `json:"updated_at"` // Time when the user was last updated, in milliseconds since the Unix epoch.
+	// The following claims are standard OIDC claims included in the `profile` scope.
+	// Logto only returns them when their values are not empty, so absent claims are
+	// left as zero values.
+	FamilyName        string   `json:"family_name"`        // The user's family name.
+	GivenName         string   `json:"given_name"`         // The user's given name.
+	MiddleName        string   `json:"middle_name"`        // The user's middle name.
+	Nickname          string   `json:"nickname"`           // The user's nickname.
+	PreferredUsername string   `json:"preferred_username"` // The username by which the user wishes to be referred to.
+	Profile           string   `json:"profile"`            // The URL of the user's profile page.
+	Website           string   `json:"website"`            // The URL of the user's website.
+	Gender            string   `json:"gender"`             // The user's gender.
+	Birthdate         string   `json:"birthdate"`          // The user's birthdate.
+	Zoneinfo          string   `json:"zoneinfo"`           // The user's time zone, e.g. `Europe/Paris`.
+	Locale            string   `json:"locale"`             // The user's locale, e.g. `en-US`.
+	Roles             []string `json:"roles"`
+	Organizations     []string `json:"organizations"`
+	OrganizationRoles []string `json:"organization_roles"`
+
+	// rawClaims holds all claims decoded from the raw JSON payload, including
+	// claims that are not modeled as struct fields. Use GetClaim to access them.
+	rawClaims map[string]any
+}
+
+// idTokenClaimsAlias is an alias of IdTokenClaims used to avoid infinite
+// recursion when unmarshaling.
+type idTokenClaimsAlias IdTokenClaims
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+// In addition to populating the modeled fields, it keeps all claims in the raw
+// JSON payload so that unmodeled claims can be accessed via GetClaim.
+func (idTokenClaims *IdTokenClaims) UnmarshalJSON(data []byte) error {
+	var alias idTokenClaimsAlias
+	if err := json.Unmarshal(data, &alias); err != nil {
+		return err
+	}
+
+	var rawClaims map[string]any
+	if err := json.Unmarshal(data, &rawClaims); err != nil {
+		return err
+	}
+
+	*idTokenClaims = IdTokenClaims(alias)
+	idTokenClaims.rawClaims = rawClaims
+
+	return nil
+}
+
+// GetClaim returns the raw value of the given claim in the ID token, including
+// claims that are not modeled as struct fields, e.g. custom claims.
+// The second return value indicates whether the claim is present.
+func (idTokenClaims IdTokenClaims) GetClaim(name string) (any, bool) {
+	value, ok := idTokenClaims.rawClaims[name]
+	return value, ok
 }
 
 type OrganizationAccessTokenClaims struct {

--- a/core/type_test.go
+++ b/core/type_test.go
@@ -1,0 +1,179 @@
+package core
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUserInfoResponseUnmarshalJsonShouldPopulateStandardProfileClaims(t *testing.T) {
+	rawUserInfoResponse := `{
+		"sub": "sub",
+		"name": "name",
+		"family_name": "Doe",
+		"given_name": "John",
+		"middle_name": "Middle",
+		"nickname": "Johnny",
+		"preferred_username": "johnny",
+		"profile": "https://example.com/johnny",
+		"website": "https://example.com",
+		"gender": "male",
+		"birthdate": "2000-01-01",
+		"zoneinfo": "Europe/Paris",
+		"locale": "en-US",
+		"created_at": 1700000000000,
+		"updated_at": 1700000001000,
+		"custom_claim": "custom_value"
+	}`
+
+	var userInfoResponse UserInfoResponse
+	unmarshalErr := json.Unmarshal([]byte(rawUserInfoResponse), &userInfoResponse)
+	assert.Nil(t, unmarshalErr)
+
+	assert.Equal(t, "sub", userInfoResponse.Sub)
+	assert.Equal(t, "name", userInfoResponse.Name)
+	assert.Equal(t, "Doe", userInfoResponse.FamilyName)
+	assert.Equal(t, "John", userInfoResponse.GivenName)
+	assert.Equal(t, "Middle", userInfoResponse.MiddleName)
+	assert.Equal(t, "Johnny", userInfoResponse.Nickname)
+	assert.Equal(t, "johnny", userInfoResponse.PreferredUsername)
+	assert.Equal(t, "https://example.com/johnny", userInfoResponse.Profile)
+	assert.Equal(t, "https://example.com", userInfoResponse.Website)
+	assert.Equal(t, "male", userInfoResponse.Gender)
+	assert.Equal(t, "2000-01-01", userInfoResponse.Birthdate)
+	assert.Equal(t, "Europe/Paris", userInfoResponse.Zoneinfo)
+	assert.Equal(t, "en-US", userInfoResponse.Locale)
+	assert.Equal(t, int64(1700000000000), userInfoResponse.CreatedAt)
+	assert.Equal(t, int64(1700000001000), userInfoResponse.UpdatedAt)
+}
+
+func TestUserInfoResponseUnmarshalJsonShouldLeaveAbsentClaimsAsZeroValues(t *testing.T) {
+	rawUserInfoResponse := `{"sub": "sub"}`
+
+	var userInfoResponse UserInfoResponse
+	unmarshalErr := json.Unmarshal([]byte(rawUserInfoResponse), &userInfoResponse)
+	assert.Nil(t, unmarshalErr)
+
+	assert.Equal(t, "sub", userInfoResponse.Sub)
+	assert.Empty(t, userInfoResponse.FamilyName)
+	assert.Empty(t, userInfoResponse.GivenName)
+	assert.Empty(t, userInfoResponse.Nickname)
+	assert.Empty(t, userInfoResponse.Locale)
+	assert.Zero(t, userInfoResponse.CreatedAt)
+	assert.Zero(t, userInfoResponse.UpdatedAt)
+
+	_, ok := userInfoResponse.GetClaim("family_name")
+	assert.False(t, ok)
+}
+
+func TestUserInfoResponseGetClaimShouldReturnAnyClaim(t *testing.T) {
+	rawUserInfoResponse := `{"sub": "sub", "custom_claim": "custom_value", "custom_data": {"level": 1}}`
+
+	var userInfoResponse UserInfoResponse
+	unmarshalErr := json.Unmarshal([]byte(rawUserInfoResponse), &userInfoResponse)
+	assert.Nil(t, unmarshalErr)
+
+	// Claims that are not modeled as struct fields are accessible via GetClaim.
+	customClaim, ok := userInfoResponse.GetClaim("custom_claim")
+	assert.True(t, ok)
+	assert.Equal(t, "custom_value", customClaim)
+
+	// Modeled claims are accessible via GetClaim as well.
+	sub, ok := userInfoResponse.GetClaim("sub")
+	assert.True(t, ok)
+	assert.Equal(t, "sub", sub)
+
+	customData, ok := userInfoResponse.GetClaim("custom_data")
+	assert.True(t, ok)
+	assert.Equal(t, map[string]any{"level": float64(1)}, customData)
+
+	// Absent claims are reported as not present.
+	_, ok = userInfoResponse.GetClaim("nonexistent_claim")
+	assert.False(t, ok)
+}
+
+func TestIdTokenClaimsUnmarshalJsonShouldPopulateStandardProfileClaims(t *testing.T) {
+	rawIdTokenClaims := `{
+		"iss": "iss",
+		"sub": "sub",
+		"aud": "aud",
+		"family_name": "Doe",
+		"given_name": "John",
+		"middle_name": "Middle",
+		"nickname": "Johnny",
+		"preferred_username": "johnny",
+		"profile": "https://example.com/johnny",
+		"website": "https://example.com",
+		"gender": "male",
+		"birthdate": "2000-01-01",
+		"zoneinfo": "Europe/Paris",
+		"locale": "en-US",
+		"created_at": 1700000000000,
+		"updated_at": 1700000001000,
+		"custom_claim": "custom_value"
+	}`
+
+	var idTokenClaims IdTokenClaims
+	unmarshalErr := json.Unmarshal([]byte(rawIdTokenClaims), &idTokenClaims)
+	assert.Nil(t, unmarshalErr)
+
+	assert.Equal(t, "iss", idTokenClaims.Iss)
+	assert.Equal(t, "sub", idTokenClaims.Sub)
+	assert.Equal(t, "aud", idTokenClaims.Aud)
+	assert.Equal(t, "Doe", idTokenClaims.FamilyName)
+	assert.Equal(t, "John", idTokenClaims.GivenName)
+	assert.Equal(t, "Middle", idTokenClaims.MiddleName)
+	assert.Equal(t, "Johnny", idTokenClaims.Nickname)
+	assert.Equal(t, "johnny", idTokenClaims.PreferredUsername)
+	assert.Equal(t, "https://example.com/johnny", idTokenClaims.Profile)
+	assert.Equal(t, "https://example.com", idTokenClaims.Website)
+	assert.Equal(t, "male", idTokenClaims.Gender)
+	assert.Equal(t, "2000-01-01", idTokenClaims.Birthdate)
+	assert.Equal(t, "Europe/Paris", idTokenClaims.Zoneinfo)
+	assert.Equal(t, "en-US", idTokenClaims.Locale)
+	assert.Equal(t, int64(1700000000000), idTokenClaims.CreatedAt)
+	assert.Equal(t, int64(1700000001000), idTokenClaims.UpdatedAt)
+}
+
+func TestIdTokenClaimsUnmarshalJsonShouldLeaveAbsentClaimsAsZeroValues(t *testing.T) {
+	rawIdTokenClaims := `{"iss": "iss", "sub": "sub"}`
+
+	var idTokenClaims IdTokenClaims
+	unmarshalErr := json.Unmarshal([]byte(rawIdTokenClaims), &idTokenClaims)
+	assert.Nil(t, unmarshalErr)
+
+	assert.Equal(t, "iss", idTokenClaims.Iss)
+	assert.Equal(t, "sub", idTokenClaims.Sub)
+	assert.Empty(t, idTokenClaims.FamilyName)
+	assert.Empty(t, idTokenClaims.GivenName)
+	assert.Empty(t, idTokenClaims.Nickname)
+	assert.Empty(t, idTokenClaims.Locale)
+	assert.Zero(t, idTokenClaims.CreatedAt)
+	assert.Zero(t, idTokenClaims.UpdatedAt)
+
+	_, ok := idTokenClaims.GetClaim("family_name")
+	assert.False(t, ok)
+}
+
+func TestIdTokenClaimsGetClaimShouldReturnAnyClaim(t *testing.T) {
+	rawIdTokenClaims := `{"iss": "iss", "sub": "sub", "custom_claim": "custom_value"}`
+
+	var idTokenClaims IdTokenClaims
+	unmarshalErr := json.Unmarshal([]byte(rawIdTokenClaims), &idTokenClaims)
+	assert.Nil(t, unmarshalErr)
+
+	// Claims that are not modeled as struct fields are accessible via GetClaim.
+	customClaim, ok := idTokenClaims.GetClaim("custom_claim")
+	assert.True(t, ok)
+	assert.Equal(t, "custom_value", customClaim)
+
+	// Modeled claims are accessible via GetClaim as well.
+	iss, ok := idTokenClaims.GetClaim("iss")
+	assert.True(t, ok)
+	assert.Equal(t, "iss", iss)
+
+	// Absent claims are reported as not present.
+	_, ok = idTokenClaims.GetClaim("nonexistent_claim")
+	assert.False(t, ok)
+}


### PR DESCRIPTION
## Summary

Add standard OIDC profile claims to `core.UserInfoResponse` and `core.IdTokenClaims`, and provide a `GetClaim` method to access any raw claim.

- Add the standard claims included in the `profile` scope to both structs: `family_name`, `given_name`, `middle_name`, `nickname`, `preferred_username`, `profile`, `website`, `gender`, `birthdate`, `zoneinfo`, and `locale`, plus `created_at` and `updated_at`
- Logto only returns these claims when their values are not empty, so they are modeled as plain fields and absent claims are left as zero values
- Both structs now keep all claims from the raw JSON payload during unmarshaling, exposed via `GetClaim(name string) (any, bool)`
- Updated the README to introduce the new fields and `GetClaim`

`GetClaim` mirrors the JS SDK behavior, where `IdTokenClaims` intersects `Record<string, unknown>` and `decodeIdToken` returns the full decoded payload, so no claim is ever dropped. With `GetClaim`, consumers can read claims that are not modeled as struct fields, e.g. custom claims or claims added in future Logto versions:

```go
idTokenClaims, err := logtoClient.GetIdTokenClaims()
if value, ok := idTokenClaims.GetClaim("custom_claim"); ok {
    // Use the claim value
}
```

### Breaking changes

None, this is additive only:

- `apidiff` against `v2` reports only additions in `core` (the new fields, `GetClaim`, and `UnmarshalJSON`) and no incompatible changes, `client` is unchanged
- Both structs already contained map/slice fields, so they were never comparable with `==`; the new unexported raw claims field does not change that
- One behavioral note: decoded values now carry the raw claims in an unexported field, so a whole-struct `reflect.DeepEqual` (e.g. testify's `assert.Equal`) between a decoded value and a hand-constructed literal no longer matches; field-level assertions are unaffected
- `json.Marshal` of these structs now emits the new fields as zero-value keys, consistent with the existing fields (none of which use `omitempty`); only byte-exact golden tests on serialized output would notice

Safe to ship as a minor release.

Closes #137

## Testing

unit tests

## Checklist

~~- [ ] `.changeset`~~
- [x] unit tests
~~- [ ] integration tests~~
- [x] necessary comments
