### PR TITLE
fix(gin-sample): return early on id token claims error

### DIFF
--- a/gin-sample/main.go
+++ b/gin-sample/main.go
@@ -88,7 +88,8 @@ func main() {
 		idTokenClaims, err := logtoClient.GetIdTokenClaims()
 
 		if err != nil {
-			ctx.String(http.StatusOK, err.Error())
+			ctx.String(http.StatusInternalServerError, err.Error())
+			return
 		}
 
 		ctx.JSON(http.StatusOK, idTokenClaims)


### PR DESCRIPTION
## Summary

Fix the `/user-id-token-claims` route in gin-sample writing the response twice when `GetIdTokenClaims` fails.

- The error branch was missing a `return`, so the handler also fell through to `ctx.JSON` and wrote a second response on top of the error message
- Add the missing `return` and use `http.StatusInternalServerError` for the error case, matching the `/sign-in` and `/sign-in-callback` routes
- Sample-only change, no library code is touched, so there is no SDK API impact

## Testing

tested locally

## Checklist

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary comments~~
