### PR TITLE
chore: sign renovate commits

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
-  ]
+    "config:recommended"
+  ],
+  "platformCommit": "enabled"
 }


### PR DESCRIPTION
## Summary

Make Renovate commit through the GitHub API so its commits are signed.

- `platformCommit` makes Renovate create commits via the GitHub API, which signs them with GitHub's key, so they show up as verified
- The `v2` branch protection requires signed commits, and Renovate pushes over plain git, so every Renovate PR was blocked from merging
- Also replaced the deprecated `config:base` preset with its current name `config:recommended`, no behavior change

## Testing

N/A

## Checklist

~~- [ ] `.changeset`~~
~~- [ ] unit tests~~
~~- [ ] integration tests~~
~~- [ ] necessary comments~~
