### PR TITLE
feat: support request context propagation

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,33 @@ if errors.As(err, &responseError) {
 }
 ```
 
+## Propagating request context
+
+`LogtoClient` methods such as `SignIn`, `HandleSignInCallback`, `GetAccessToken`, `FetchUserInfo`, and `SignOut` send HTTP requests to Logto. To propagate cancellation, deadlines, and tracing information from the incoming request to those calls, bind the client to the request's `context.Context` with `client.WithContext`. A `LogtoClient` is created per incoming request together with its session storage, so pass that request's context:
+
+```go
+func handler(w http.ResponseWriter, r *http.Request) {
+	logtoClient := client.NewLogtoClient(logtoConfig, storage, client.WithContext(r.Context()))
+	// ...
+}
+```
+
+In Gin, use `c.Request.Context()`.
+
+`WithContext` composes with `WithHttpClient`, which injects a custom `*http.Client`. With an OpenTelemetry-instrumented transport, the spans created for SDK requests are parented to the incoming request's span:
+
+```go
+// Reuse one instrumented HTTP client across requests.
+httpClient := &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)}
+
+logtoClient := client.NewLogtoClient(logtoConfig, storage,
+	client.WithHttpClient(httpClient),
+	client.WithContext(r.Context()),
+)
+```
+
+Without `WithContext`, SDK requests use `context.Background()`. The `core` package offers the same capability through `Context` variants of its request functions, such as `core.FetchOidcConfigContext` and `core.FetchTokenByRefreshTokenContext`; the existing functions keep working unchanged.
+
 ## Running behind a reverse proxy
 
 By default, `HandleSignInCallback` reconstructs the callback URI from the incoming request, inferring the scheme from the TLS state (or the `X-Forwarded-Proto` header) and the host from the `Host` header.

--- a/client/client.go
+++ b/client/client.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -42,11 +43,21 @@ func WithHttpClient(client *http.Client) LogtoClientOption {
 	}
 }
 
+// WithContext binds ctx to every request the LogtoClient sends to Logto, so that
+// cancellation, deadlines, and tracing information propagate to those requests.
+// A LogtoClient is scoped to a single incoming request, so pass that request's context.
+func WithContext(ctx context.Context) LogtoClientOption {
+	return func(c *LogtoClient) {
+		c.ctx = ctx
+	}
+}
+
 type LogtoClient struct {
 	httpClient     *http.Client
 	logtoConfig    *LogtoConfig
 	storage        Storage
 	accessTokenMap map[string]AccessToken
+	ctx            context.Context
 }
 
 func NewLogtoClient(config *LogtoConfig, storage Storage, opts ...LogtoClientOption) *LogtoClient {
@@ -56,6 +67,7 @@ func NewLogtoClient(config *LogtoConfig, storage Storage, opts ...LogtoClientOpt
 		logtoConfig:    config,
 		storage:        storage,
 		accessTokenMap: make(map[string]AccessToken),
+		ctx:            context.Background(),
 	}
 
 	// Apply options
@@ -139,7 +151,7 @@ func (logtoClient *LogtoClient) GetAccessTokenWithOptions(options GetAccessToken
 		return AccessToken{}, fetchOidcConfigErr
 	}
 
-	refreshedToken, refreshTokenErr := core.FetchTokenByRefreshToken(logtoClient.httpClient, &core.FetchTokenByRefreshTokenOptions{
+	refreshedToken, refreshTokenErr := core.FetchTokenByRefreshTokenContext(logtoClient.ctx, logtoClient.httpClient, &core.FetchTokenByRefreshTokenOptions{
 		TokenEndpoint:  oidcConfig.TokenEndpoint,
 		ClientId:       logtoClient.logtoConfig.AppId,
 		ClientSecret:   logtoClient.logtoConfig.AppSecret,
@@ -258,5 +270,5 @@ func (logtoClient *LogtoClient) FetchUserInfo() (core.UserInfoResponse, error) {
 		return core.UserInfoResponse{}, getAccessTokenErr
 	}
 
-	return core.FetchUserInfoWithClient(logtoClient.httpClient, oidcConfig.UserinfoEndpoint, accessToken.Token)
+	return core.FetchUserInfoContext(logtoClient.ctx, logtoClient.httpClient, oidcConfig.UserinfoEndpoint, accessToken.Token)
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,8 +1,11 @@
 package client
 
 import (
+	"context"
 	"errors"
+	"io"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -66,8 +69,8 @@ func TestGetAccessTokenShouldReturnNotAuthenticatedErrWhenRefreshTokenIsRejected
 	}
 
 	patchesForFetchTokenByRefreshToken := gomonkey.ApplyFunc(
-		core.FetchTokenByRefreshToken,
-		func(client *http.Client, options *core.FetchTokenByRefreshTokenOptions) (core.RefreshTokenResponse, error) {
+		core.FetchTokenByRefreshTokenContext,
+		func(ctx context.Context, client *http.Client, options *core.FetchTokenByRefreshTokenOptions) (core.RefreshTokenResponse, error) {
 			return core.RefreshTokenResponse{}, testResponseError
 		},
 	)
@@ -105,8 +108,8 @@ func TestGetAccessTokenShouldPropagateOtherResponseErrorsAsIs(t *testing.T) {
 	}
 
 	patchesForFetchTokenByRefreshToken := gomonkey.ApplyFunc(
-		core.FetchTokenByRefreshToken,
-		func(client *http.Client, options *core.FetchTokenByRefreshTokenOptions) (core.RefreshTokenResponse, error) {
+		core.FetchTokenByRefreshTokenContext,
+		func(ctx context.Context, client *http.Client, options *core.FetchTokenByRefreshTokenOptions) (core.RefreshTokenResponse, error) {
 			return core.RefreshTokenResponse{}, testResponseError
 		},
 	)
@@ -153,8 +156,8 @@ func TestGetAccessTokenShouldReturnFetchedAccessTokenAndUpdateLocalAccessTokenIf
 	defer patchesForCreateRemoteJwks.Reset()
 
 	patchesForFetchTokenByRefreshToken := gomonkey.ApplyFunc(
-		core.FetchTokenByRefreshToken,
-		func(client *http.Client, options *core.FetchTokenByRefreshTokenOptions) (core.RefreshTokenResponse, error) {
+		core.FetchTokenByRefreshTokenContext,
+		func(ctx context.Context, client *http.Client, options *core.FetchTokenByRefreshTokenOptions) (core.RefreshTokenResponse, error) {
 			return testRefreshTokenResponse, nil
 		},
 	)
@@ -258,7 +261,7 @@ func TestFetchUserInfoShouldReturnCorrectUserInfoResponse(t *testing.T) {
 	})
 	defer patchesForGetAccessToken.Reset()
 
-	patchesCoreFetchUserInfo := gomonkey.ApplyFunc(core.FetchUserInfoWithClient, func(client *http.Client, userInfoEndpoint, accessToken string) (core.UserInfoResponse, error) {
+	patchesCoreFetchUserInfo := gomonkey.ApplyFunc(core.FetchUserInfoContext, func(ctx context.Context, client *http.Client, userInfoEndpoint, accessToken string) (core.UserInfoResponse, error) {
 		return testUserInfoResponse, nil
 	})
 	defer patchesCoreFetchUserInfo.Reset()
@@ -412,4 +415,56 @@ func TestLogtoClientShouldUseCustomHttpClientForFetchUserInfo(t *testing.T) {
 	// This test verifies that the LogtoClient is configured with the custom HTTP client
 	// The actual FetchUserInfo will use this client when making HTTP requests
 	assert.NotNil(t, logtoClient.httpClient)
+}
+
+type roundTripperFunc func(request *http.Request) (*http.Response, error)
+
+func (roundTrip roundTripperFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return roundTrip(request)
+}
+
+type testContextKey struct{}
+
+func TestNewLogtoClientShouldUseBackgroundContextWhenNoOptionsProvided(t *testing.T) {
+	logtoClient := NewLogtoClient(&LogtoConfig{}, &TestStorage{})
+
+	assert.Equal(t, context.Background(), logtoClient.ctx)
+}
+
+func TestNewLogtoClientShouldUseCustomContextWhenWithContextOptionProvided(t *testing.T) {
+	ctx := context.WithValue(context.Background(), testContextKey{}, "value")
+
+	logtoClient := NewLogtoClient(&LogtoConfig{}, &TestStorage{}, WithContext(ctx))
+
+	assert.Equal(t, ctx, logtoClient.ctx)
+}
+
+func TestLogtoClientShouldBindContextToRequestsSentToLogto(t *testing.T) {
+	ctx := context.WithValue(context.Background(), testContextKey{}, "value")
+
+	var requestContext context.Context
+	httpClient := &http.Client{
+		Transport: roundTripperFunc(func(request *http.Request) (*http.Response, error) {
+			requestContext = request.Context()
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{},
+				Body:       io.NopCloser(strings.NewReader(`{"authorization_endpoint":"https://example.com/oidc/auth"}`)),
+			}, nil
+		}),
+	}
+
+	logtoClient := NewLogtoClient(
+		&LogtoConfig{Endpoint: "https://example.com"},
+		&TestStorage{data: map[string]string{}},
+		WithHttpClient(httpClient),
+		WithContext(ctx),
+	)
+
+	_, signInErr := logtoClient.SignInWithRedirectUri("https://my-app.com/sign-in-callback")
+	assert.Nil(t, signInErr)
+
+	if assert.NotNil(t, requestContext) {
+		assert.Equal(t, "value", requestContext.Value(testContextKey{}))
+	}
 }

--- a/client/handle_sign_in_callback.go
+++ b/client/handle_sign_in_callback.go
@@ -36,7 +36,7 @@ func (logtoClient *LogtoClient) HandleSignInCallback(request *http.Request) erro
 		return fetchOidcConfigErr
 	}
 
-	codeTokenResponse, fetchTokenErr := core.FetchTokenByAuthorizationCode(logtoClient.httpClient, &core.FetchTokenByAuthorizationCodeOptions{
+	codeTokenResponse, fetchTokenErr := core.FetchTokenByAuthorizationCodeContext(logtoClient.ctx, logtoClient.httpClient, &core.FetchTokenByAuthorizationCodeOptions{
 		TokenEndpoint: oidcConfig.TokenEndpoint,
 		Code:          code,
 		CodeVerifier:  signInSession.CodeVerifier,

--- a/client/handle_sign_in_callback_test.go
+++ b/client/handle_sign_in_callback_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -32,8 +33,8 @@ func TestHandleSignInCallbackShouldHandleCallbackCorrectly(t *testing.T) {
 	defer patchesForVerifyAndParseCodeFromCallbackUri.Reset()
 
 	patchesForFetchTokenByAuthorizationCode := gomonkey.ApplyFunc(
-		core.FetchTokenByAuthorizationCode,
-		func(client *http.Client, options *core.FetchTokenByAuthorizationCodeOptions) (core.CodeTokenResponse, error) {
+		core.FetchTokenByAuthorizationCodeContext,
+		func(ctx context.Context, client *http.Client, options *core.FetchTokenByAuthorizationCodeOptions) (core.CodeTokenResponse, error) {
 			return testCodeTokenResponse, nil
 		},
 	)
@@ -96,8 +97,8 @@ func TestHandleSignInCallbackShouldUseBaseUrlToConstructCallbackUriWhenBaseUrlIs
 
 	codeUsedToFetchToken := ""
 	patchesForFetchTokenByAuthorizationCode := gomonkey.ApplyFunc(
-		core.FetchTokenByAuthorizationCode,
-		func(client *http.Client, options *core.FetchTokenByAuthorizationCodeOptions) (core.CodeTokenResponse, error) {
+		core.FetchTokenByAuthorizationCodeContext,
+		func(ctx context.Context, client *http.Client, options *core.FetchTokenByAuthorizationCodeOptions) (core.CodeTokenResponse, error) {
 			codeUsedToFetchToken = options.Code
 			return testCodeTokenResponse, nil
 		},

--- a/client/helper.go
+++ b/client/helper.go
@@ -13,7 +13,7 @@ func (logtoClient *LogtoClient) fetchOidcConfig() (core.OidcConfigResponse, erro
 	if constructEndpointErr != nil {
 		return core.OidcConfigResponse{}, constructEndpointErr
 	}
-	return core.FetchOidcConfig(logtoClient.httpClient, discoveryEndpoint)
+	return core.FetchOidcConfigContext(logtoClient.ctx, logtoClient.httpClient, discoveryEndpoint)
 }
 
 func (logtoClient *LogtoClient) loadAccessTokenMap() {
@@ -40,7 +40,7 @@ func (logtoClient *LogtoClient) persistAccessTokenMap() {
 }
 
 func (logtoClient *LogtoClient) createRemoteJwks(jwksUri string) (*jose.JSONWebKeySet, error) {
-	jwksResponse, fetchJwksErr := core.FetchJwks(logtoClient.httpClient, jwksUri)
+	jwksResponse, fetchJwksErr := core.FetchJwksContext(logtoClient.ctx, logtoClient.httpClient, jwksUri)
 	if fetchJwksErr != nil {
 		return nil, fetchJwksErr
 	}

--- a/client/helper_test.go
+++ b/client/helper_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"net/http"
 	"strconv"
 	"testing"
@@ -49,7 +50,7 @@ func TestFetchOidcConfigShouldReturnExpectedOidcConfig(t *testing.T) {
 		AuthorizationEndpoint: "testAuthorizationEndpoint",
 	}
 
-	patches := gomonkey.ApplyFunc(core.FetchOidcConfig, func(client *http.Client, endpoint string) (core.OidcConfigResponse, error) {
+	patches := gomonkey.ApplyFunc(core.FetchOidcConfigContext, func(ctx context.Context, client *http.Client, endpoint string) (core.OidcConfigResponse, error) {
 		return testOidcConfig, nil
 	})
 	defer patches.Reset()

--- a/client/sign_out.go
+++ b/client/sign_out.go
@@ -19,7 +19,7 @@ func (logtoClient *LogtoClient) SignOut(postLogoutRedirectUri string) (string, e
 	}
 
 	if refreshToken != "" {
-		_ = core.Revoke(logtoClient.httpClient, &core.RevocationOptions{
+		_ = core.RevokeContext(logtoClient.ctx, logtoClient.httpClient, &core.RevocationOptions{
 			RevocationEndpoint: oidcConfig.RevocationEndpoint,
 			ClientId:           logtoClient.logtoConfig.AppId,
 			Token:              refreshToken,

--- a/client/sign_out_test.go
+++ b/client/sign_out_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -23,7 +24,7 @@ func TestSignOutShouldSignOutUserSuccessfully(t *testing.T) {
 	})
 	defer patchesForFetchOidcConfig.Reset()
 
-	patchesForRevoke := gomonkey.ApplyFunc(core.Revoke, func(client *http.Client, options *core.RevocationOptions) error {
+	patchesForRevoke := gomonkey.ApplyFunc(core.RevokeContext, func(ctx context.Context, client *http.Client, options *core.RevocationOptions) error {
 		return nil
 	})
 	defer patchesForRevoke.Reset()

--- a/core/context_test.go
+++ b/core/context_test.go
@@ -1,0 +1,109 @@
+package core
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type roundTripperFunc func(request *http.Request) (*http.Response, error)
+
+func (roundTrip roundTripperFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return roundTrip(request)
+}
+
+type testContextKey struct{}
+
+func TestContextVariantsShouldBindContextToRequest(t *testing.T) {
+	ctx := context.WithValue(context.Background(), testContextKey{}, "value")
+
+	var requestContext context.Context
+	client := &http.Client{
+		Transport: roundTripperFunc(func(request *http.Request) (*http.Response, error) {
+			requestContext = request.Context()
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{},
+				Body:       io.NopCloser(strings.NewReader(`{}`)),
+			}, nil
+		}),
+	}
+
+	testCases := []struct {
+		name string
+		call func() error
+	}{
+		{
+			name: "FetchOidcConfigContext",
+			call: func() error {
+				_, err := FetchOidcConfigContext(ctx, client, "https://example.com/oidc/.well-known/openid-configuration")
+				return err
+			},
+		},
+		{
+			name: "FetchJwksContext",
+			call: func() error {
+				_, err := FetchJwksContext(ctx, client, "https://example.com/oidc/jwks")
+				return err
+			},
+		},
+		{
+			name: "FetchTokenByAuthorizationCodeContext",
+			call: func() error {
+				_, err := FetchTokenByAuthorizationCodeContext(ctx, client, &FetchTokenByAuthorizationCodeOptions{
+					TokenEndpoint: "https://example.com/oidc/token",
+				})
+				return err
+			},
+		},
+		{
+			name: "FetchTokenByRefreshTokenContext",
+			call: func() error {
+				_, err := FetchTokenByRefreshTokenContext(ctx, client, &FetchTokenByRefreshTokenOptions{
+					TokenEndpoint: "https://example.com/oidc/token",
+				})
+				return err
+			},
+		},
+		{
+			name: "FetchUserInfoContext",
+			call: func() error {
+				_, err := FetchUserInfoContext(ctx, client, "https://example.com/oidc/me", "accessToken")
+				return err
+			},
+		},
+		{
+			name: "RevokeContext",
+			call: func() error {
+				return RevokeContext(ctx, client, &RevocationOptions{
+					RevocationEndpoint: "https://example.com/oidc/revoke",
+				})
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			requestContext = nil
+
+			assert.Nil(t, testCase.call())
+
+			if assert.NotNil(t, requestContext) {
+				assert.Equal(t, "value", requestContext.Value(testContextKey{}))
+			}
+		})
+	}
+}
+
+func TestContextVariantsShouldAbortRequestWhenContextIsCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, fetchOidcConfigErr := FetchOidcConfigContext(ctx, &http.Client{}, "https://example.com/oidc/.well-known/openid-configuration")
+
+	assert.ErrorIs(t, fetchOidcConfigErr, context.Canceled)
+}

--- a/core/fetch_jwks.go
+++ b/core/fetch_jwks.go
@@ -1,13 +1,27 @@
 package core
 
-import "net/http"
+import (
+	"context"
+	"net/http"
+)
 
 type JwksResponse struct {
 	Keys []map[string]string `json:"keys"`
 }
 
 func FetchJwks(client *http.Client, jwksUri string) (JwksResponse, error) {
-	response, requestErr := client.Get(jwksUri)
+	return FetchJwksContext(context.Background(), client, jwksUri)
+}
+
+// FetchJwksContext is like FetchJwks but binds the request to ctx.
+func FetchJwksContext(ctx context.Context, client *http.Client, jwksUri string) (JwksResponse, error) {
+	request, createRequestErr := http.NewRequestWithContext(ctx, "GET", jwksUri, nil)
+
+	if createRequestErr != nil {
+		return JwksResponse{}, createRequestErr
+	}
+
+	response, requestErr := client.Do(request)
 
 	if requestErr != nil {
 		return JwksResponse{}, requestErr

--- a/core/fetch_token.go
+++ b/core/fetch_token.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"net/http"
 	"net/url"
 	"strings"
@@ -17,6 +18,11 @@ type FetchTokenByAuthorizationCodeOptions struct {
 }
 
 func FetchTokenByAuthorizationCode(client *http.Client, options *FetchTokenByAuthorizationCodeOptions) (CodeTokenResponse, error) {
+	return FetchTokenByAuthorizationCodeContext(context.Background(), client, options)
+}
+
+// FetchTokenByAuthorizationCodeContext is like FetchTokenByAuthorizationCode but binds the request to ctx.
+func FetchTokenByAuthorizationCodeContext(ctx context.Context, client *http.Client, options *FetchTokenByAuthorizationCodeOptions) (CodeTokenResponse, error) {
 	values := url.Values{
 		"client_id":     {options.ClientId},
 		"redirect_uri":  {options.RedirectUri},
@@ -28,10 +34,10 @@ func FetchTokenByAuthorizationCode(client *http.Client, options *FetchTokenByAut
 	if options.Resource != "" {
 		values.Add("resource", options.Resource)
 	}
-	request, createRequestErr := http.NewRequest("POST", options.TokenEndpoint, strings.NewReader(values.Encode()))
+	request, createRequestErr := http.NewRequestWithContext(ctx, "POST", options.TokenEndpoint, strings.NewReader(values.Encode()))
 
 	if createRequestErr != nil {
-		return RefreshTokenResponse{}, createRequestErr
+		return CodeTokenResponse{}, createRequestErr
 	}
 
 	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -69,6 +75,11 @@ type FetchTokenByRefreshTokenOptions struct {
 }
 
 func FetchTokenByRefreshToken(client *http.Client, options *FetchTokenByRefreshTokenOptions) (RefreshTokenResponse, error) {
+	return FetchTokenByRefreshTokenContext(context.Background(), client, options)
+}
+
+// FetchTokenByRefreshTokenContext is like FetchTokenByRefreshToken but binds the request to ctx.
+func FetchTokenByRefreshTokenContext(ctx context.Context, client *http.Client, options *FetchTokenByRefreshTokenOptions) (RefreshTokenResponse, error) {
 	values := url.Values{
 		"client_id":     {options.ClientId},
 		"refresh_token": {options.RefreshToken},
@@ -87,7 +98,7 @@ func FetchTokenByRefreshToken(client *http.Client, options *FetchTokenByRefreshT
 		values.Add("organization_id", options.OrganizationId)
 	}
 
-	request, createRequestErr := http.NewRequest("POST", options.TokenEndpoint, strings.NewReader(values.Encode()))
+	request, createRequestErr := http.NewRequestWithContext(ctx, "POST", options.TokenEndpoint, strings.NewReader(values.Encode()))
 
 	if createRequestErr != nil {
 		return RefreshTokenResponse{}, createRequestErr

--- a/core/fetch_user_info.go
+++ b/core/fetch_user_info.go
@@ -1,12 +1,20 @@
 package core
 
-import "net/http"
+import (
+	"context"
+	"net/http"
+)
 
 // FetchUserInfoWithClient fetches user info using a custom HTTP client.
 // This function allows you to use a custom HTTP client for observability,
 // tracing, or other custom configurations.
 func FetchUserInfoWithClient(client *http.Client, userInfoEndpoint, accessToken string) (UserInfoResponse, error) {
-	request, createRequestErr := http.NewRequest("GET", userInfoEndpoint, nil)
+	return FetchUserInfoContext(context.Background(), client, userInfoEndpoint, accessToken)
+}
+
+// FetchUserInfoContext is like FetchUserInfoWithClient but binds the request to ctx.
+func FetchUserInfoContext(ctx context.Context, client *http.Client, userInfoEndpoint, accessToken string) (UserInfoResponse, error) {
+	request, createRequestErr := http.NewRequestWithContext(ctx, "GET", userInfoEndpoint, nil)
 
 	if createRequestErr != nil {
 		return UserInfoResponse{}, createRequestErr

--- a/core/oidc_config.go
+++ b/core/oidc_config.go
@@ -1,11 +1,23 @@
 package core
 
 import (
+	"context"
 	"net/http"
 )
 
 func FetchOidcConfig(client *http.Client, endpoint string) (OidcConfigResponse, error) {
-	response, fetchErr := client.Get(endpoint)
+	return FetchOidcConfigContext(context.Background(), client, endpoint)
+}
+
+// FetchOidcConfigContext is like FetchOidcConfig but binds the request to ctx.
+func FetchOidcConfigContext(ctx context.Context, client *http.Client, endpoint string) (OidcConfigResponse, error) {
+	request, createRequestErr := http.NewRequestWithContext(ctx, "GET", endpoint, nil)
+
+	if createRequestErr != nil {
+		return OidcConfigResponse{}, createRequestErr
+	}
+
+	response, fetchErr := client.Do(request)
 
 	if fetchErr != nil {
 		return OidcConfigResponse{}, fetchErr

--- a/core/revoke.go
+++ b/core/revoke.go
@@ -1,9 +1,11 @@
 package core
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 )
 
 type RevocationOptions struct {
@@ -13,11 +15,24 @@ type RevocationOptions struct {
 }
 
 func Revoke(client *http.Client, options *RevocationOptions) error {
+	return RevokeContext(context.Background(), client, options)
+}
+
+// RevokeContext is like Revoke but binds the request to ctx.
+func RevokeContext(ctx context.Context, client *http.Client, options *RevocationOptions) error {
 	values := url.Values{
 		"client_id": {options.ClientId},
 		"token":     {options.Token},
 	}
-	response, fetchErr := client.PostForm(options.RevocationEndpoint, values)
+	request, createRequestErr := http.NewRequestWithContext(ctx, "POST", options.RevocationEndpoint, strings.NewReader(values.Encode()))
+
+	if createRequestErr != nil {
+		return createRequestErr
+	}
+
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	response, fetchErr := client.Do(request)
 
 	if fetchErr != nil {
 		return fetchErr


### PR DESCRIPTION
## Summary

Add first-class `context.Context` support so that cancellation, deadlines, and tracing information propagate to every request the SDK sends to Logto.

- `client.WithContext(ctx)`: a new `LogtoClientOption` that binds the context to all outbound requests of a `LogtoClient`. It composes with `WithHttpClient`, so an `otelhttp` transport picks up the parent span from the context.
- `core`: `Context` variants of the request functions (`FetchOidcConfigContext`, `FetchJwksContext`, `FetchTokenByAuthorizationCodeContext`, `FetchTokenByRefreshTokenContext`, `FetchUserInfoContext`, `RevokeContext`). The existing functions delegate to them with `context.Background()`.
- Without `WithContext`, behavior is unchanged, so no existing caller is affected.
- README: new "Propagating request context" section.

No breaking changes: `apidiff` against `v2` reports only additions (`client.WithContext` and the six `core.*Context` functions).

Closes #175

## Testing

unit tests

## Checklist

- ~~`.changeset`~~
- [x] unit tests
- ~~integration tests~~
- [x] necessary comments
