### PR TITLE
ci: use major-version-suffixed module path for go module index

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,9 +36,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v7
+
+      - name: Setup Go Env
+        uses: actions/setup-go@v7
+        with:
+          go-version: '^1.19'
+
       # https://pkg.go.dev/about#adding-a-package
       - name: Request proxy.golang.org to update go module index
-        env:
-          MODULE_NAME: github.com/logto-io/go
         run: |
-          curl "https://proxy.golang.org/$MODULE_NAME/@v/${GITHUB_REF#refs/*/}.info"
+          MODULE_NAME="$(go list -m)"
+          curl -fsS "https://proxy.golang.org/$MODULE_NAME/@v/${GITHUB_REF#refs/*/}.info"


### PR DESCRIPTION
## Summary

Fix the release workflow's proxy.golang.org request, which has been a silent no-op since the module path gained the `/v2` suffix.

- `MODULE_NAME` was hardcoded to `github.com/logto-io/go`, so the request returned 404 (`go.mod has post-v2 module path "github.com/logto-io/go/v2"`).
- Derive the module path with `go list -m` instead of hardcoding it, so future major versions keep working without an edit.
- Add `-fsS` to `curl` so a future breakage fails the step instead of passing silently.

## Testing

Tested locally: `curl -fsS "https://proxy.golang.org/$(go list -m)/@v/v2.3.0.info"` returns 200.

## Checklist

- [ ] `.changeset`
- [ ] unit tests
- [ ] integration tests
- [ ] necessary TSDoc comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)
